### PR TITLE
Test case for multipleOf plus modified test case parsing floats as decimal.Decimal

### DIFF
--- a/json/tests/draft4/multipleOf.json
+++ b/json/tests/draft4/multipleOf.json
@@ -56,5 +56,21 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "92.6 by 0.1",
+        "schema": {"multipleOf": 0.1},
+        "tests": [
+            {
+                "description": "92.6 is multiple of 0.1",
+                "data": 92.6,
+                "valid": true
+            },
+            {
+                "description": "92.61 is not multiple of 0.1",
+                "data": 92.61,
+                "valid": false
+            }
+        ]
     }
 ]

--- a/jsonschema/tests/test_jsonschema_test_suite.py
+++ b/jsonschema/tests/test_jsonschema_test_suite.py
@@ -17,6 +17,7 @@ import os
 import re
 import subprocess
 import sys
+import decimal
 
 try:
     from sys import pypy_version_info
@@ -97,7 +98,7 @@ def load_json_cases(tests_glob, ignore_glob="", basedir=TESTS_DIR, skip=None):
             id = itertools.count(1)
 
             with open(filename) as test_file:
-                for case in json.load(test_file):
+                for case in json.load(test_file, parse_float=decimal.Decimal):
                     for test in case["tests"]:
                         name = "test_%s_%s_%s" % (
                             validating,


### PR DESCRIPTION
Added test case validating, that `92.6` is `multipleOf` `0.1`.

Test case Python code had to be modified to parse floats as `decimal.Decimal` as with float it fails due to limited float number precision representation.