### PR TITLE
Improve mutlipleOf validator with floating point value.

### DIFF
--- a/jsonschema/_validators.py
+++ b/jsonschema/_validators.py
@@ -5,9 +5,6 @@ from jsonschema.exceptions import FormatError, ValidationError
 from jsonschema.compat import iteritems
 
 
-FLOAT_TOLERANCE = 10 ** -15
-
-
 def patternProperties(validator, patternProperties, instance, schema):
     if not validator.is_type(instance, "object"):
         return
@@ -111,8 +108,8 @@ def multipleOf(validator, dB, instance, schema):
         return
 
     if isinstance(dB, float):
-        mod = instance % dB
-        failed = (mod > FLOAT_TOLERANCE) and (dB - mod) > FLOAT_TOLERANCE
+        quotient = instance / dB
+        failed = int(quotient) != quotient
     else:
         failed = instance % dB
 


### PR DESCRIPTION
Example:
```
>>> 150.0 % 0.01
0.009999999999996878
>>> 0.01 - 0.009999999999996878
3.1225022567582528e-15
>>> 150.0 / 0.01
15000.0
```

I've prepared a commit against json-schema/JSON-Schema-Test-Suite adding following test case:
```
    {
        "schema": {"multipleOf": 0.01},
        "tests": [
            {
                "description": "150.0 is multiple of 0.01",
                "data": 150.0,
                "valid": true
            },
            {
                "description": "150.0001 is not multiple of 0.01",
                "data": 150.0001,
                "valid": false
            }
        ]
    }
```
but am not sure it is the right place to put such test nor how to choose "better" values without relying on implementation (does implementatio use modulo ? on double or single precision ? etc). As a result, I could not come up with a meaningful description. Anyway, this test fails with current implementation with:
  ValidationError: 150.0 is not a multiple of 0.01
and is fixed with attached patch.