### PR TITLE
Fix flaky errors with py3

### DIFF
--- a/jsonschema/_validators.py
+++ b/jsonschema/_validators.py
@@ -9,8 +9,8 @@ def patternProperties(validator, patternProperties, instance, schema):
     if not validator.is_type(instance, "object"):
         return
 
-    for pattern, subschema in iteritems(patternProperties):
-        for k, v in iteritems(instance):
+    for pattern, subschema in sorted(iteritems(patternProperties)):
+        for k, v in sorted(iteritems(instance)):
             if re.search(pattern, k):
                 for error in validator.descend(
                     v, subschema, path=k, schema_path=pattern,
@@ -166,7 +166,7 @@ def dependencies(validator, dependencies, instance, schema):
     if not validator.is_type(instance, "object"):
         return
 
-    for property, dependency in iteritems(dependencies):
+    for property, dependency in sorted(iteritems(dependencies)):
         if property not in instance:
             continue
 
@@ -220,7 +220,7 @@ def properties_draft3(validator, properties, instance, schema):
     if not validator.is_type(instance, "object"):
         return
 
-    for property, subschema in iteritems(properties):
+    for property, subschema in sorted(iteritems(properties)):
         if property in instance:
             for error in validator.descend(
                 instance[property],
@@ -271,7 +271,7 @@ def properties_draft4(validator, properties, instance, schema):
     if not validator.is_type(instance, "object"):
         return
 
-    for property, subschema in iteritems(properties):
+    for property, subschema in sorted(iteritems(properties)):
         if property in instance:
             for error in validator.descend(
                 instance[property],


### PR DESCRIPTION
We ran into some test failures while using `jsonschema==2.4.0` with python3.  The failures were intermittent (approximately 1 in every 10 runs), but were reproducible in both py33 and py34 (py26 and py27 were unaffected).

You can see the failures in travis-ci for this PR https://github.com/Yelp/swagger_spec_validator/pull/11 or use that branch to reproduce them (`tox -e py34`). The best example is `test_success` in [this build](https://travis-ci.org/Yelp/swagger_spec_validator/jobs/52218198#L384).

[The code calling `jsonschema`](https://github.com/Yelp/swagger_spec_validator/blob/master/swagger_spec_validator/common.py#L24,L34) is pretty straightforward:

```python
resolver = RefResolver('file://{0}'.format(schema_path), schema)
jsonschema.validate(json_document, schema, resolver=resolver)
```

The error is:
```
Unresolvable JSON pointer: 'definitions/simpleTypes'
```

I added a bunch of debugging to `jsonschema` to see what was happening. From what I can tell, `RefResolver.resolve_fragment()` is being called with a ref of `definitions/simpleTypes` **but** the current base_uri in the `RefResolver` is actually `http://swagger.io/v2/schema.json` instead of what it should be (`http://json-schema.org/draft-04/schema`).

I also noticed that the ordering was totally undefined, every run would produce a different call stack.  Some orderings would fail, and some would succeed, but there was definitely more than one order which caused it to fail.  I tried a few things, and found that adding this `sorted()` to iterations before `descend()` resolved the problem.  I tried with `list()` as well, but that didn't solve the problem.

Without being able to completely explain the problem, I can say that this fixes it. My understanding is that some combination of the undefined order of fields, and the lazy evaluation of `iteritems()` causes some call stack which results in the wrong state.


