### PR TITLE
CLI option --filter: validate multiple instances from stdin.

### DIFF
--- a/jsonschema/tests/test_cli.py
+++ b/jsonschema/tests/test_cli.py
@@ -1,3 +1,5 @@
+import json
+
 from jsonschema import Draft4Validator, ValidationError, cli
 from jsonschema.compat import StringIO
 from jsonschema.tests.compat import mock, unittest
@@ -15,6 +17,11 @@ def fake_validator(*errors):
                 return errors.pop()
             return []
     return FakeValidator
+
+
+def serialize_instances(*instances):
+    """:Return: a string with `instances` serialized to JSON, one per line."""
+    return '\n'.join(json.dumps(instance, separators=(',', ':')) for instance in instances) + '\n'
 
 
 class TestParser(unittest.TestCase):
@@ -107,4 +114,32 @@ class TestCLI(unittest.TestCase):
         )
         self.assertFalse(stdout.getvalue())
         self.assertEqual(stderr.getvalue(), "1 - 9\t1 - 8\t2 - 7\t")
+        self.assertEqual(exit_code, 1)
+
+    def test_filter_valid(self):
+        serialized = serialize_instances(1, [2], {3: 4})
+        stdin, stdout, stderr = StringIO(serialized), StringIO(), StringIO()
+        exit_code = cli.run({
+            "validator": fake_validator(),
+            "schema": {},
+            "error_format": "{error.message}",
+            "filter": True,
+        }, stdin=stdin, stdout=stdout, stderr=stderr)
+        self.assertFalse(stderr.getvalue())
+        self.assertEquals(stdout.getvalue(), serialized)
+        self.assertEqual(exit_code, 0)
+
+    def test_filter_invalid(self):
+        schema = {"type": "object"}
+        serialized_in = serialize_instances({}, [2], {3: 4})
+        serialized_out = serialize_instances({}, {3: 4})
+        stdin, stdout, stderr = StringIO(serialized_in), StringIO(), StringIO()
+        exit_code = cli.run({
+            "validator": Draft4Validator,
+            "schema": schema,
+            "error_format": "{error.message}",
+            "filter": True,
+            }, stdin=stdin, stdout=stdout, stderr=stderr)
+        self.assertEquals(stderr.getvalue(), "[2] is not of type 'object'")
+        self.assertEquals(stdout.getvalue(), serialized_out)
         self.assertEqual(exit_code, 1)


### PR DESCRIPTION
Reads JSON instances one to a line from stdin, outputs those
that validate in compact form (one to a line).  Print errors
to stderr for those that do not validate.
