### PR TITLE
Add link to latest Travis build.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,6 @@
 .. image:: https://travis-ci.org/Julian/jsonschema.svg?branch=master
+    :target: https://travis-ci.org/Julian/jsonschema
+
 ==========
 jsonschema
 ==========


### PR DESCRIPTION
Just a personal pet peeve, feel free to ignore this PR: I like when clicking the Travis badge will get me to the Travis page, so I can check easily if the build failed for some bug in Travis or some bug in the code.