### PR TITLE
Fix formatting error for unique items if instance is a tuple

### DIFF
--- a/jsonschema/_validators.py
+++ b/jsonschema/_validators.py
@@ -133,7 +133,7 @@ def uniqueItems(validator, uI, instance, schema):
         validator.is_type(instance, "array") and
         not _utils.uniq(instance)
     ):
-        yield ValidationError("%r has non-unique elements" % instance)
+        yield ValidationError("%r has non-unique elements" % (instance,))
 
 
 def pattern(validator, patrn, instance, schema):


### PR DESCRIPTION
I have found very uncommon, but still a bug, with formatting error messages for unique items, when instance is a tuple.

Attached a test case to reproduce:

```
import unittest

from jsonschema.exceptions import ValidationError
from jsonschema.validators import Draft4Validator, validate


TEST_SCHEMA = {
    'type': 'array',
    'items': {
        'type': 'number',
    },
    'minItems': 2,
    'maxItems': 3,
    'uniqueItems': True,
}


TYPES = Draft4Validator.DEFAULT_TYPES.copy()
TYPES['array'] = (list, tuple)


class Validator(Draft4Validator):

    DEFAULT_TYPES = TYPES


class TestItemsErrorMessages(unittest.TestCase):

    array_type = list
    validator_class = Draft4Validator

    def check_error_message(self, instance):
        self.assertRaises(ValidationError,
                          validate,
                          instance,
                          TEST_SCHEMA,
                          self.validator_class)

    def test_min_items(self):
        self.check_error_message(self.array_type([1]))

    def test_max_items(self):
        self.check_error_message(self.array_type([1, 2, 3, 4]))

    def test_unique_items(self):
        self.check_error_message(self.array_type([1, 1, 2]))


class TestItemsErrorMessagesCustomValidator(TestItemsErrorMessages):

    array_type = tuple
    validator_class = Validator


if __name__ == '__main__':
    unittest.main()
```

Its results:

```
playpauseandstop@shep:~/Projects/rororo$ env/bin/python ../jsonschema_unique_items.py 
.....E
======================================================================
ERROR: test_unique_items (__main__.TestItemsErrorMessagesCustomValidator)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "../jsonschema_unique_items.py", line 46, in test_unique_items
    self.check_error_message(self.array_type([1, 1, 2]))
  File "../jsonschema_unique_items.py", line 37, in check_error_message
    self.validator_class)
  File "/home/playpauseandstop/.pyenv/versions/3.4.3/lib/python3.4/unittest/case.py", line 704, in assertRaises
    return context.handle('assertRaises', callableObj, args, kwargs)
  File "/home/playpauseandstop/.pyenv/versions/3.4.3/lib/python3.4/unittest/case.py", line 162, in handle
    callable_obj(*args, **kwargs)
  File "/home/playpauseandstop/Projects/rororo/env/lib/python3.4/site-packages/jsonschema/validators.py", line 428, in validate
    cls(schema, *args, **kwargs).validate(instance)
  File "/home/playpauseandstop/Projects/rororo/env/lib/python3.4/site-packages/jsonschema/validators.py", line 116, in validate
    for error in self.iter_errors(*args, **kwargs):
  File "/home/playpauseandstop/Projects/rororo/env/lib/python3.4/site-packages/jsonschema/validators.py", line 95, in iter_errors
    for error in errors:
  File "/home/playpauseandstop/Projects/rororo/env/lib/python3.4/site-packages/jsonschema/_validators.py", line 139, in uniqueItems
    yield ValidationError("%r has non-unique elements" % instance)
TypeError: not all arguments converted during string formatting

----------------------------------------------------------------------
Ran 6 tests in 0.012s

FAILED (errors=1)
```

And the reason is easy, when formatting min/max items error messages you use ``'%r' % (instance,)`` statements, but for unique items don't, so when tuple is an instance, this broken validation message.