### PR TITLE
Fix universal wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,20 +23,15 @@ classifiers = [
 ]
 
 
-extras_require = {"format" : ["rfc3987", "strict-rfc3339", "webcolors"]}
-if sys.version_info[:2] == (2, 6):
-    install_requires = ["argparse", "repoze.lru"]
-elif sys.version_info[:2] == (2, 7):
-    install_requires = ["functools32"]
-else:
-    install_requires = []
+extras_require = {"format" : ["rfc3987", "strict-rfc3339", "webcolors"],
+                              ":python_version=='2.6'": ["argparse", "repoze.lru"],
+                              ":python_version=='2.7'": ["functools32"]}
 
 setup(
     name="jsonschema",
     packages=["jsonschema", "jsonschema.tests"],
     package_data={"jsonschema": ["schemas/*.json"]},
     setup_requires=["vcversioner"],
-    install_requires=install_requires,
     extras_require=extras_require,
     author="Julian Berman",
     author_email="Julian@GrayVines.com",


### PR DESCRIPTION
The current universal wheels have static install_requires matching the python version they were built on: so a wheel built on 2.6 claims it needs argparse and repoze.lru on 2.7 and 3.4, etc. This clearly doesn't work :)

environment markers are however honoured by wheels and pip, using this somewhat ugly syntax in extras (I'm looking to improve that, but this works - see the distutils-sig list for some discussion on it recently).