### PR TITLE
Set cause to the correct value during FormatError.

### DIFF
--- a/jsonschema/_validators.py
+++ b/jsonschema/_validators.py
@@ -149,7 +149,7 @@ def format(validator, format, instance, schema):
         try:
             validator.format_checker.check(instance, format)
         except FormatError as error:
-            yield ValidationError(error.message, cause=error.cause)
+            yield ValidationError(error.message, cause=error)
 
 
 def minLength(validator, mL, instance, schema):


### PR DESCRIPTION
When reading the documentation and reading the source code of jsonschema
I found an inconsitency in the code.

Basically, when a FormatError occurs, it's re-raised into a
ValidationError with its cause set to the original FormatError according
to the documentation. Which makes a lot of sense.

But in the code, the cause of the ValidationError is set to the cause of
the FormatError. Which is not the documented behaviour nor very useful
(in my opinion); So I consider this as a bug.

See the documentation here:
https://python-jsonschema.readthedocs.org/en/latest/errors/#jsonschema.exceptions.ValidationError.cause