### PR TITLE
Replace rfc3987 (GPL) with rfc3986 (Apache)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ _static
 _templates
 
 TODO
+*.pyc
+.eggs/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ TODO
 *.pyc
 .eggs/
 .idea/
+.tox/
+jsonschema.egg-info/

--- a/jsonschema/_format.py
+++ b/jsonschema/_format.py
@@ -158,7 +158,7 @@ def is_host_name(instance):
 
 
 try:
-    import rfc3987
+    import rfc3986
 except ImportError:
     pass
 else:
@@ -166,8 +166,10 @@ else:
     def is_uri(instance):
         if not isinstance(instance, str_types):
             return True
-        return rfc3987.parse(instance, rule="URI")
-
+        elif not rfc3986.is_valid_uri(instance, require_scheme=True):
+            return False
+        else:
+            return rfc3986.normalize_uri(instance)
 
 try:
     import strict_rfc3339

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 extras_require = {
-    "format" : ["rfc3987", "strict-rfc3339", "webcolors"],
+    "format" : ["rfc3986", "strict-rfc3339", "webcolors"],
     ":python_version=='2.6'": ["argparse", "repoze.lru"],
     ":python_version=='2.7'": ["functools32"],
 }


### PR DESCRIPTION
We'd like to consider using the jsonschema package which is licensed under an MIT-like license, but cannot take a dependency on rfc3987 because it is distributed under GPL.

This was the minimum amount of changes required to make the tests pass, we're open to any feedback on these changes!