### PR TITLE
only check strings for patternProperties matches

### DIFF
--- a/jsonschema/_utils.py
+++ b/jsonschema/_utils.py
@@ -97,7 +97,9 @@ def find_additional_properties(instance, schema):
     patterns = "|".join(schema.get("patternProperties", {}))
     for property in instance:
         if property not in properties:
-            if patterns and re.search(patterns, property):
+            if (patterns and
+                    isinstance(property, str_types) and
+                    re.search(patterns, property)):
                 continue
             yield property
 

--- a/jsonschema/_validators.py
+++ b/jsonschema/_validators.py
@@ -11,7 +11,7 @@ def patternProperties(validator, patternProperties, instance, schema):
 
     for pattern, subschema in iteritems(patternProperties):
         for k, v in iteritems(instance):
-            if re.search(pattern, k):
+            if validator.is_type(k, "string") and re.search(pattern, k):
                 for error in validator.descend(
                     v, subschema, path=k, schema_path=pattern,
                 ):


### PR DESCRIPTION
Fixes #285 

I looked over the tests, but wasn't able to infer the appropriate place to add test cases for these errors. Should I add two new tests to test_validators.py - one for the patternProperties validator and another for the additionalProperties validator?
