### PR TITLE
Made required_draft4 more robust when used with Draft3

### DIFF
--- a/jsonschema/_validators.py
+++ b/jsonschema/_validators.py
@@ -296,6 +296,11 @@ def properties_draft4(validator, properties, instance, schema):
 def required_draft4(validator, required, instance, schema):
     if not validator.is_type(instance, "object"):
         return
+
+    if not isinstance(required, list):
+        yield ValidationError("Found Draft3 style 'required' restriction")
+        return
+
     for property in required:
         if property not in instance:
             yield ValidationError("%r is a required property" % property)

--- a/jsonschema/cli.py
+++ b/jsonschema/cli.py
@@ -65,6 +65,10 @@ def run(arguments, stdout=sys.stdout, stderr=sys.stderr):
     error_format = arguments["error_format"]
     validator = arguments["validator"](schema=arguments["schema"])
     errored = False
+
+    # add a check to the schema file first
+    validator.check_schema(arguments["schema"])
+
     for instance in arguments["instances"] or ():
         for error in validator.iter_errors(instance):
             stderr.write(error_format.format(error=error))


### PR DESCRIPTION
When I try to validate a Draft3 schema using the Draft4 validator, you get the following error:

```
  File "/usr/lib/python3/dist-packages/jsonschema/_validators.py", line 299, in required_draft4
    for property in required:
TypeError: 'bool' object is not iterable
```

My change _fixes_ this issue by alerting the use to the mis-match in draft versions.