### PR TITLE
Fix relative references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /jsonschema/_version.py
 /version.txt
-.idea
 
 _cache
 _static

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /jsonschema/_version.py
 /version.txt
+.idea
 
 _cache
 _static

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -777,14 +777,6 @@ class TestRefResolver(unittest.TestCase):
         parts = unquote(fragment).split(u"/") if fragment else []
 
         for part in parts:
-            part = part.replace(u"~1", u"/").replace(u"~0", u"~")
-
-            if isinstance(document, Sequence):
-                # Array indexes should be turned into integers
-                try:
-                    part = int(part)
-                except ValueError:
-                    pass
             try:
                 document = document[part]
             except (TypeError, LookupError):

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -954,8 +954,12 @@ class TestRefResolver(unittest.TestCase):
             }
         }
         resolver = RefResolver.from_schema(schema)
-        resolver.resolve_fragment = mock.MagicMock(side_effect=self.prev_resolve_fragment)
-        self.assertRaises(RefResolutionError, resolver.resolve_fragment, schema, "#/definitions/Category")
+        resolver.resolve_fragment = mock.MagicMock(
+            side_effect=self.prev_resolve_fragment)
+        self.assertRaises(RefResolutionError,
+                          resolver.resolve_fragment,
+                          schema,
+                          "#/definitions/Category")
 
     def test_resolve_fragment(self):
         schema = {
@@ -990,7 +994,9 @@ class TestRefResolver(unittest.TestCase):
             }
         }
         resolver = RefResolver.from_schema(schema)
-        self.assertEqual(resolver.resolve_fragment(schema, "#/definitions/Category"), schema['definitions']['Category'])
+        self.assertEqual(resolver.resolve_fragment
+                         (schema, "#/definitions/Category"),
+                         schema['definitions']['Category'])
 
 
 class UniqueTupleItemsMixin(object):

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -8,7 +8,7 @@ from jsonschema.validators import (
     RefResolutionError, UnknownType, Draft3Validator,
     Draft4Validator, RefResolver, create, extend, validator_for, validate
 )
-from jsonschema.compat import Sequence, unquote
+from jsonschema.compat import unquote
 
 
 class TestCreateAndExtend(unittest.TestCase):
@@ -923,24 +923,14 @@ class TestRefResolver(unittest.TestCase):
                             "items": {
                                 "$ref": "#/definitions/Category"
                             }
-                        },
-                        "name": {
-                            "type": "string"
                         }
                     }
                 },
                 "Category": {
-                    "required": [
-                        "name"
-                    ],
                     "properties": {
                         "name": {
                             "type": "string"
                         },
-                        "id": {
-                            "type": "integer",
-                            "format": "int32"
-                        }
                     }
                 }
             }
@@ -963,24 +953,14 @@ class TestRefResolver(unittest.TestCase):
                             "items": {
                                 "$ref": "#/definitions/Category"
                             }
-                        },
-                        "name": {
-                            "type": "string"
                         }
                     }
                 },
                 "Category": {
-                    "required": [
-                        "name"
-                    ],
                     "properties": {
                         "name": {
                             "type": "string"
                         },
-                        "id": {
-                            "type": "integer",
-                            "format": "int32"
-                        }
                     }
                 }
             }

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -14,7 +14,6 @@ from jsonschema.compat import (
     Sequence, urljoin, urlsplit, urldefrag, unquote, urlopen,
     str_types, int_types, iteritems, lru_cache,
 )
-from jsonschema.exceptions import ErrorTree  # Backwards compatibility  # noqa
 from jsonschema.exceptions import RefResolutionError, SchemaError, UnknownType
 
 

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -356,7 +356,7 @@ class RefResolver(object):
 
         """
 
-        fragment = fragment.lstrip(u"/")
+        fragment = fragment.lstrip(u"#").lstrip(u"/")
         parts = unquote(fragment).split(u"/") if fragment else []
 
         for part in parts:

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -15,7 +15,7 @@ from jsonschema.compat import (
     str_types, int_types, iteritems, lru_cache,
 )
 from jsonschema.exceptions import RefResolutionError, SchemaError, UnknownType
-
+from jsonschema.exceptions import ErrorTree  # Backwards compatibility  # noqa
 
 _unset = _utils.Unset()
 


### PR DESCRIPTION
Currently, calling the resolve_fragment method of the RefResolver class to return the JSON referenced by the pointer of a $ref key fails if the pointer is preceded by a `#` character. The JSON schema specs specify this format, e.g. { "$ref": "#/definitions/address" }. Specifically, the following exception is raised: jsonschema.exceptions.RefResolutionError: Unresolvable JSON pointer. This happens even if the pointer is valid.  

I made changes to the resolve_fragment method of the RefResolver class in jsonschema/validators.py to strip away this character, and now the pointer resolves correctly. I also added two tests to jsonschema/tests/test_validators.py to demonstrate this behavior of the old method and to show the results of the revised method. Let me know if you have any questions.