### PR TITLE
Fix "tox -e coverage" and add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,15 @@ _cache
 _static
 _templates
 
-TODO
+# Byte-compiled / optimized / DLL files
+*.py[cod]
+
+# Distribution / packaging
+.eggs/
+build/
+*.egg-info/
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,7 @@ commands =
     coverage html
 deps =
     coverage
+    green
 
 
 [testenv:docs]


### PR DESCRIPTION
The coverage testenv uses green, so I added it to the dependencies for that testenv. I also added the basics to the .gitignore file.