### PR TITLE
Make better loop performance more intuitive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
 language: python
 sudo: false
-addons:
-  apt:
-    sources:
-      - deadsnakes
-    packages:
-      - python3.5
 python:
   - "2.7"
+  - "3.5"
+  - "pypy"
+  - "pypy3"
 install:
-  - pip install tox
+  - pip install tox-travis
 script:
   - tox

--- a/README.rst
+++ b/README.rst
@@ -14,22 +14,22 @@ for Python (supporting 2.7+ including Python 3).
 
 .. code-block:: python
 
-    >>> from jsonschema import validate
+    >>> from jsonschema import Schema
 
     >>> # A sample schema, like what we'd get from json.load()
-    >>> schema = {
+    >>> schema = Schema({
     ...     "type" : "object",
     ...     "properties" : {
     ...         "price" : {"type" : "number"},
     ...         "name" : {"type" : "string"},
     ...     },
-    ... }
+    ... })
 
     >>> # If no exception is raised by validate(), the instance is valid.
-    >>> validate({"name" : "Eggs", "price" : 34.99}, schema)
+    >>> schema.validate({"name" : "Eggs", "price" : 34.99})
 
-    >>> validate(
-    ...     {"name" : "Eggs", "price" : "Invalid"}, schema
+    >>> schema.validate(
+    ...     {"name" : "Eggs", "price" : "Invalid"}
     ... )                                   # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
         ...

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,22 +11,22 @@ for Python (supporting 2.7+ including Python 3).
 
 .. code-block:: python
 
-    >>> from jsonschema import validate
+    >>> from jsonschema import Schema
 
     >>> # A sample schema, like what we'd get from json.load()
-    >>> schema = {
+    >>> schema = Schema({
     ...     "type" : "object",
     ...     "properties" : {
     ...         "price" : {"type" : "number"},
     ...         "name" : {"type" : "string"},
     ...     },
-    ... }
+    ... })
 
     >>> # If no exception is raised by validate(), the instance is valid.
-    >>> validate({"name" : "Eggs", "price" : 34.99}, schema)
+    >>> schema.validate({"name" : "Eggs", "price" : 34.99})
 
-    >>> validate(
-    ...     {"name" : "Eggs", "price" : "Invalid"}, schema
+    >>> schema.validate(
+    ...     {"name" : "Eggs", "price" : "Invalid"}
     ... )                                   # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
         ...

--- a/jsonschema/__init__.py
+++ b/jsonschema/__init__.py
@@ -16,7 +16,7 @@ from jsonschema._format import (
     FormatChecker, draft3_format_checker, draft4_format_checker,
 )
 from jsonschema.validators import (
-    Draft3Validator, Draft4Validator, RefResolver, validate
+    Draft3Validator, Draft4Validator, RefResolver, validate, Schema
 )
 
 from jsonschema._version import __version__

--- a/jsonschema/exceptions.py
+++ b/jsonschema/exceptions.py
@@ -85,7 +85,7 @@ class _Error(Exception):
         __str__ = __unicode__
     else:
         def __str__(self):
-            return unicode(self).encode("utf-8")
+            return self.__unicode__().encode("utf-8")
 
     @classmethod
     def create_from(cls, other):
@@ -158,7 +158,7 @@ class UnknownType(Exception):
         __str__ = __unicode__
     else:
         def __str__(self):
-            return unicode(self).encode("utf-8")
+            return self.__unicode__().encode("utf-8")
 
 
 class FormatError(Exception):
@@ -174,7 +174,7 @@ class FormatError(Exception):
         __str__ = __unicode__
     else:
         def __str__(self):
-            return self.message.encode("utf-8")
+            return self.__unicode__().encode("utf-8")
 
 
 class ErrorTree(object):

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -7,6 +7,7 @@ from jsonschema.tests.compat import mock, unittest
 from jsonschema.validators import (
     RefResolutionError, UnknownType, Draft3Validator,
     Draft4Validator, RefResolver, create, extend, validator_for, validate,
+    Schema,
 )
 
 
@@ -756,6 +757,14 @@ class TestValidate(unittest.TestCase):
     def test_draft4_validator_is_the_default(self):
         with mock.patch.object(Draft4Validator, "check_schema") as chk_schema:
             validate({}, {})
+            chk_schema.assert_called_once_with({})
+
+
+class TestSchemaCls(unittest.TestCase):
+    def test_draft4_validator_is_the_default_for_schema_cls(self):
+        with mock.patch.object(Draft4Validator, "check_schema") as chk_schema:
+            schema = Schema({})
+            schema.validate({})
             chk_schema.assert_called_once_with({})
 
 

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -539,3 +539,36 @@ def validate(instance, schema, cls=None, *args, **kwargs):
         cls = validator_for(schema)
     cls.check_schema(schema)
     cls(schema, *args, **kwargs).validate(instance)
+
+
+class Schema(object):
+    """
+    Similar to :func:`validate`, except the :class:`IValidator` is initialized
+    only once when this class is initialized. This can be useful for improving
+    the performance of validation in loops.
+
+    :argument schema: the schema to validate with
+    :argument validator_cls: an :class:`IValidator` class that will be used by
+                             :meth:`validate` to validate the instance.
+
+    :raises:
+        :exc:`SchemaError` if the schema itself is invalid
+    """
+
+    def __init__(self, schema, validator_cls=None, *args, **kwargs):
+        if validator_cls is None:
+            validator_cls = validator_for(schema)
+        validator_cls.check_schema(schema)
+        self.validator = validator_cls(schema, *args, **kwargs)
+
+    def validate(self, instance):
+        """
+        Validate an instance with the schema and :class:`IValidator` class used
+        in this instance of :class:`Schema`.
+
+        :argument instance: the instance to validate
+
+        :raises:
+            :exc:`ValidationError` if the instance is invalid
+        """
+        self.validator.validate(instance)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,9 @@
 [tox]
 envlist = py{27,35,py,py3}, docs, style
 
+[tox:travis]
+2.7 = py27, style
+3.5 = py35, docs, style
 
 [testenv]
 setenv =


### PR DESCRIPTION
This PR adds a `Schema` class to be used like:
```
schema = Schema({
    "type" : "object",
    "properties" : {
        "price" : {"type" : "number"},
        "name" : {"type" : "string"},
    },
})

schema.validate({"name" : "Eggs", "price" : 34.99})
```

When the `Schema` object is initialized, it will check if the schema is valid and will initialize the validator class. This allows you to initialize the validator and check the schema only once, instead of doing it each time `validate` is called.

The goal is to make it a lot more intuitive for new users to get better performance in loops or web application endpoints without needing to learn about `Draft4Validator.validate()` and why it's faster. It's also a better alternative to directly using `Draft4Validator.validate()` because it will still validate the schema.

Here's a gist I was using to benchmark: https://gist.github.com/pawl/382c655f31dad631ab29775a6c8cad05