### PR TITLE
Improve travis and tox build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: python
-sudo: false
-addons:
-  apt:
-    sources:
-      - deadsnakes
-    packages:
-      - python3.5
 python:
-  - "2.7"
+ - "2.7"
+ - "3.3"
+ - "3.4"
+ - "3.5"
+ - "3.6"
+ - "pypy"
 install:
-  - pip install tox
+  - pip install tox-travis
 script:
   - tox
+sudo: false

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,py}, docs, style
+envlist = py{27,33,34,35,36,py}, docs, style
 
 
 [testenv]


### PR DESCRIPTION
This will hopefully add Python 3.3, 3.4, and 3.6 testing as well as
simplify the travis management via the tox-travis tool.