### PR TITLE
Fixes the currently failing json-schema-test-suite tests

### DIFF
--- a/json/README.md
+++ b/json/README.md
@@ -155,6 +155,7 @@ for more information.
 ### PostgreSQL ###
 
 * [postgres-json-schema](https://github.com/gavinwahl/postgres-json-schema)
+* [is_jsonb_valid](https://github.com/furstenheim/is_jsonb_valid)
 
 If you use it as well, please fork and send a pull request adding yourself to
 the list :).

--- a/json/tests/draft4/optional/format.json
+++ b/json/tests/draft4/optional/format.json
@@ -25,13 +25,78 @@
         "schema": {"format": "uri"},
         "tests": [
             {
-                "description": "a valid URI",
+                "description": "a valid URL with anchor tag",
                 "data": "http://foo.bar/?baz=qux#quux",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with anchor tag and parantheses",
+                "data": "http://foo.com/blah_(wikipedia)_blah#cite-1",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with URL-encoded stuff",
+                "data": "http://foo.bar/?q=Test%20URL-encoded%20stuff",
+                "valid": true
+            },
+            {
+                "description": "a valid puny-coded URL ",
+                "data": "http://xn--nw2a.xn--j6w193g/",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with many special characters",
+                "data": "http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid URL based on IPv4",
+                "data": "http://223.255.255.254",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with ftp scheme",
+                "data": "ftp://ftp.is.co.za/rfc/rfc1808.txt",
+                "valid": true
+            },
+            {
+                "description": "a valid URL for a simple text file",
+                "data": "http://www.ietf.org/rfc/rfc2396.txt",
+                "valid": true
+            },
+            {
+                "description": "a valid URL ",
+                "data": "ldap://[2001:db8::7]/c=GB?objectClass?one",
+                "valid": true
+            },
+            {
+                "description": "a valid mailto URI",
+                "data": "mailto:John.Doe@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid newsgroup URI",
+                "data": "news:comp.infosystems.www.servers.unix",
+                "valid": true
+            },
+            {
+                "description": "a valid tel URI",
+                "data": "tel:+1-816-555-1212",
+                "valid": true
+            },
+            {
+                "description": "a valid URN",
+                "data": "urn:oasis:names:specification:docbook:dtd:xml:4.1.2",
                 "valid": true
             },
             {
                 "description": "an invalid protocol-relative URI Reference",
                 "data": "//foo.bar/?baz=qux#quux",
+                "valid": false
+            },
+            {
+                "description": "an invalid relative URI Reference",
+                "data": "/abc",
                 "valid": false
             },
             {
@@ -42,6 +107,16 @@
             {
                 "description": "an invalid URI though valid URI reference",
                 "data": "abc",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI with spaces",
+                "data": "http:// shouldfail.com",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI with spaces and missing scheme",
+                "data": ":// should fail",
                 "valid": false
             }
         ]

--- a/json/tests/draft6/const.json
+++ b/json/tests/draft6/const.json
@@ -47,6 +47,27 @@
         ]
     },
     {
+        "description": "const with array",
+        "schema": {"const": [{ "foo": "bar" }]},
+        "tests": [
+            {
+                "description": "same array is valid",
+                "data": [{"foo": "bar"}],
+                "valid": true
+            },
+            {
+                "description": "another array item is invalid",
+                "data": [2],
+                "valid": false
+            },
+            {
+                "description": "array with additional items is invalid",
+                "data": [1, 2, 3],
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "const with null",
         "schema": {"const": null},
         "tests": [

--- a/json/tests/draft6/optional/format.json
+++ b/json/tests/draft6/optional/format.json
@@ -25,8 +25,68 @@
         "schema": {"format": "uri"},
         "tests": [
             {
-                "description": "a valid URI",
+                "description": "a valid URL with anchor tag",
                 "data": "http://foo.bar/?baz=qux#quux",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with anchor tag and parantheses",
+                "data": "http://foo.com/blah_(wikipedia)_blah#cite-1",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with URL-encoded stuff",
+                "data": "http://foo.bar/?q=Test%20URL-encoded%20stuff",
+                "valid": true
+            },
+            {
+                "description": "a valid puny-coded URL ",
+                "data": "http://xn--nw2a.xn--j6w193g/",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with many special characters",
+                "data": "http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid URL based on IPv4",
+                "data": "http://223.255.255.254",
+                "valid": true
+            },
+            {
+                "description": "a valid URL with ftp scheme",
+                "data": "ftp://ftp.is.co.za/rfc/rfc1808.txt",
+                "valid": true
+            },
+            {
+                "description": "a valid URL for a simple text file",
+                "data": "http://www.ietf.org/rfc/rfc2396.txt",
+                "valid": true
+            },
+            {
+                "description": "a valid URL ",
+                "data": "ldap://[2001:db8::7]/c=GB?objectClass?one",
+                "valid": true
+            },
+            {
+                "description": "a valid mailto URI",
+                "data": "mailto:John.Doe@example.com",
+                "valid": true
+            },
+            {
+                "description": "a valid newsgroup URI",
+                "data": "news:comp.infosystems.www.servers.unix",
+                "valid": true
+            },
+            {
+                "description": "a valid tel URI",
+                "data": "tel:+1-816-555-1212",
+                "valid": true
+            },
+            {
+                "description": "a valid URN",
+                "data": "urn:oasis:names:specification:docbook:dtd:xml:4.1.2",
                 "valid": true
             },
             {
@@ -47,6 +107,16 @@
             {
                 "description": "an invalid URI though valid URI reference",
                 "data": "abc",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI with spaces",
+                "data": "http:// shouldfail.com",
+                "valid": false
+            },
+            {
+                "description": "an invalid URI with spaces and missing scheme",
+                "data": ":// should fail",
                 "valid": false
             }
         ]

--- a/jsonschema/_format.py
+++ b/jsonschema/_format.py
@@ -296,6 +296,8 @@ else:
         draft6="json-pointer", raises=jsonpointer.JsonPointerException,
     )
     def is_json_pointer(instance):
+        if not isinstance(instance, str_types):
+            return True
         return jsonpointer.JsonPointer(instance)
 
 

--- a/jsonschema/_validators.py
+++ b/jsonschema/_validators.py
@@ -391,6 +391,15 @@ def type(validator, types, instance, schema):
         yield ValidationError(_utils.types_msg(instance, types))
 
 
+def type_draft6(validator, types, instance, schema):
+    # Draft 6 changes integer type to include floats with no fractional part
+    if isinstance(instance, float) and "integer" in types and instance.is_integer():
+        return
+
+    for e in type(validator, types, instance, schema):
+        yield e
+
+
 def properties(validator, properties, instance, schema):
     if not validator.is_type(instance, "object"):
         return

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ extras_require = {
         "jsonpointer>1.13",
         "rfc3987",
         "strict-rfc3339",
-        "uritemplate>3.0.0",
+        "uritemplate>=3.0.0",
         "webcolors",
     ],
     ":python_version=='2.7'": ["functools32"],


### PR DESCRIPTION
Currently using jsonschema at work and interested in getting draft6 support finalised. To jump in, I've provided a couple of quick fixes for the previously failing tests. 

Before:
`FAILED (skips=47, failures=3, errors=10, successes=1209)`
After:
`PASSED (skips=47, successes=1254)`

Note that I pulled in the latest tests from the JSON schema test suit repo. 

I was hesitant to have `RefResolver` needing to know about id vs $id, but I could see no other way without removing `RefResolver.from_schema()` from the interface. I also briefly looked at the tests being skipped, which appear to require `RefResolver` to be able to parse the id attribute, but I'll comment on that separately. 