### PR TITLE
perf: Make is_type faster and cleaner

### DIFF
--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -140,13 +140,10 @@ def create(meta_schema, validators=(), version=None, default_types=None):
             pytypes = self._types[type]
 
             # bool inherits from int, so ensure bools aren't reported as ints
-            if isinstance(instance, bool):
-                pytypes = _utils.flatten(pytypes)
-                is_number = any(
-                    issubclass(pytype, numbers.Number) for pytype in pytypes
-                )
-                if is_number and bool not in pytypes:
-                    return False
+            if (isinstance(instance, bool) and
+                issubclass(int, pytypes) and
+                bool not in _utils.flatten(pytypes)):
+                return False
             return isinstance(instance, pytypes)
 
         def is_valid(self, instance, _schema=None):


### PR DESCRIPTION
Instead of flattening to find out `is_number`, we can just check `issubclass(int, pytypes)` which doesn't require flattening the types list. Only if that passes do we need to look further.