### PR TITLE
Move requests import to runtime

### DIFF
--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -7,11 +7,6 @@ import numbers
 
 from six import add_metaclass
 
-try:
-    import requests
-except ImportError:
-    requests = None
-
 from jsonschema import _utils, _validators, _types
 from jsonschema.compat import (
     Sequence, urljoin, urlsplit, urldefrag, unquote, urlopen,
@@ -671,6 +666,10 @@ class RefResolver(object):
         .. _requests: http://pypi.python.org/pypi/requests/
 
         """
+        try:
+            import requests
+        except ImportError:
+            requests = None
 
         scheme = urlsplit(uri).scheme
 


### PR DESCRIPTION
Importing requests takes well over 100ms and is used only for resolving refs from remote URIs - move the import to runtime.

--

Hopefully the test case modification is ok too - mocking a runtime import was not something I've done before :) If there is more elegant or "industry standard" solution, please let me know, and I'll fix it.