### PR TITLE
Update setup.py syntax for pipenv (bug) compliancy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ import os
 
 from setuptools import setup
 
-
 with open(os.path.join(os.path.dirname(__file__), "README.rst")) as readme:
     long_description = readme.read()
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ classifiers = [
 ]
 
 extras_require = {
-    "format": ["rfc3987", "strict-rfc3339", "webcolors"]
+    "format": ["rfc3987", "strict-rfc3339", "webcolors"],
 }
 
 setup(
@@ -43,7 +43,7 @@ setup(
 
     install_requires=[
         "attrs>=17.3.0", "pyrsistent>=0.14.0", "six>=1.11.0",
-        "functools32;python_version<'3'"
+        "functools32;python_version<'3'",
     ],
     extras_require=extras_require,
 

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,7 @@ classifiers = [
 ]
 
 extras_require = {
-    "format": ["rfc3987", "strict-rfc3339", "webcolors"],
-    ":python_version=='2.7'": ["functools32"],
+    "format": ["rfc3987", "strict-rfc3339", "webcolors"]
 }
 
 setup(
@@ -42,7 +41,10 @@ setup(
     setup_requires=["setuptools_scm"],
     use_scm_version=True,
 
-    install_requires=["attrs>=17.3.0", "pyrsistent>=0.14.0", "six>=1.11.0"],
+    install_requires=[
+        "attrs>=17.3.0", "pyrsistent>=0.14.0", "six>=1.11.0"
+        "functools32;python_version<'3'"
+    ],
     extras_require=extras_require,
 
     packages=["jsonschema", "jsonschema.tests"],

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     use_scm_version=True,
 
     install_requires=[
-        "attrs>=17.3.0", "pyrsistent>=0.14.0", "six>=1.11.0"
+        "attrs>=17.3.0", "pyrsistent>=0.14.0", "six>=1.11.0",
         "functools32;python_version<'3'"
     ],
     extras_require=extras_require,


### PR DESCRIPTION
Hi,

I'm using your library (cool, thanks!) and I'm migrating my project to using [pipenv](https://docs.pipenv.org/) instead of pip.

Pipenv [has a bug](https://github.com/pypa/pipenv/issues/1279#issuecomment-364623908) that prevents to correctly parse the old `extra_requires` syntax. Apparently this syntax is old and superseded by `install_requires`.

In short, what happens is that in my py3 virtualenv, pipenv wrongly installs `functools32` and that breaks the whole package installation process. 

This patch allows me to use `jsonschema` in my project migrated to pipenv.

I'd be happy to have your opinion on this small patch, thanks!