### PR TITLE
Fix: Convert properties to string before regex

### DIFF
--- a/jsonschema/_utils.py
+++ b/jsonschema/_utils.py
@@ -101,7 +101,10 @@ def find_additional_properties(instance, schema):
     patterns = "|".join(schema.get("patternProperties", {}))
     for property in instance:
         if property not in properties:
-            if patterns and re.search(patterns, property):
+            prop = property
+            if not isinstance(prop, str):
+                prop = str(property)
+            if patterns and re.search(patterns, prop):
                 continue
             yield property
 

--- a/jsonschema/_validators.py
+++ b/jsonschema/_validators.py
@@ -11,7 +11,7 @@ def patternProperties(validator, patternProperties, instance, schema):
 
     for pattern, subschema in iteritems(patternProperties):
         for k, v in iteritems(instance):
-            if re.search(pattern, k):
+            if re.search(pattern, str(k)):
                 for error in validator.descend(
                     v, subschema, path=k, schema_path=pattern,
                 ):


### PR DESCRIPTION
It is not uncommon for developers to create schemas in YAML, for example
when developing an Open API Specification. When keys are numeric and
parsed with the yaml parser they are typed and throw an error when
attempting to validate patternProperties or similar pattern matching
validation. This changeset converts the property to a string before
attempting to match the regex.