### PR TITLE
Attach additional properties error to each bad key

### DIFF
--- a/jsonschema/_validators.py
+++ b/jsonschema/_validators.py
@@ -55,8 +55,9 @@ def additionalProperties(validator, aP, instance, schema):
             )
             yield ValidationError(error)
         else:
-            error = "Additional properties are not allowed (%s %s unexpected)"
-            yield ValidationError(error % _utils.extras_msg(extras))
+            for extra in extras:
+                error = "Additional properties are not allowed (%s was unexpected)"
+                yield ValidationError(error % extra, path=[extra])
 
 
 def items_draft3_draft4(validator, items, instance, schema):


### PR DESCRIPTION
Instead of a single error for unexpected additional properties attached
to the container dict()'s path, create an error for each unexpected key
and include the key in the path. This is useful when parsing errors to
identify the exact failing object, which is helpful when identifying
the location of the failing key.

In the particular case of using the ruamel.yaml parser, line & column
numbers are preserved in the data structure, and having the full path to
the failing key means error messages can include the line & column
numbers.

Signed-off-by: Grant Likely <grant.likely@arm.com>
Signed-off-by: Rob Herring <robh@kernel.org>