### PR TITLE
Handle $id property for draft6 in validates()

### DIFF
--- a/docs/spelling-wordlist.txt
+++ b/docs/spelling-wordlist.txt
@@ -15,6 +15,7 @@ indices
 ipv
 iterable
 jsonschema
+pre
 programmatically
 recurses
 regex

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -76,6 +76,28 @@ class TestCreateAndExtend(TestCase):
             validators.create(meta_schema={u"id": "id"})
         self.assertFalse(validates.called)
 
+    def test_if_validates_registers_meta_schema_id(self):
+        meta_schema_key = "meta schema id"
+        my_meta_schema = {u"id": meta_schema_key}
+
+        validators.create(
+            meta_schema=my_meta_schema,
+            version="my version",
+        )
+
+        self.assertIn(meta_schema_key, validators.meta_schemas)
+
+    def test_if_validates_registers_meta_schema_draft6_id(self):
+        meta_schema_key = "meta schema $id"
+        my_meta_schema = {u"$id": meta_schema_key}
+
+        validators.create(
+            meta_schema=my_meta_schema,
+            version="my version",
+        )
+
+        self.assertIn(meta_schema_key, validators.meta_schemas)
+
     def test_extend(self):
         original_validators = dict(self.Validator.VALIDATORS)
         new = mock.Mock()
@@ -1020,6 +1042,17 @@ class TestValidatorFor(TestCase):
             version="12",
         )
         schema = {"$schema": "meta schema id"}
+        self.assertIs(
+            validators.validator_for(schema),
+            Validator,
+        )
+
+    def test_custom_validator_draft6(self):
+        Validator = validators.create(
+            meta_schema={"$id": "meta schema $id"},
+            version="13",
+        )
+        schema = {"$schema": "meta schema $id"}
         self.assertIs(
             validators.validator_for(schema),
             Validator,

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -36,7 +36,9 @@ def validates(version):
     Register the decorated validator for a ``version`` of the specification.
 
     Registered validators and their meta schemas will be considered when
-    parsing ``$schema`` properties' URIs.
+    parsing ``$schema`` properties' URIs. Meta schemas can use either
+    ``id`` or ``$id`` depending on whether they follow pre-draft6 or draft6
+    and later, respectively.
 
     Arguments:
 
@@ -54,6 +56,8 @@ def validates(version):
         validators[version] = cls
         if u"id" in cls.META_SCHEMA:
             meta_schemas[cls.META_SCHEMA[u"id"]] = cls
+        elif u"$id" in cls.META_SCHEMA:
+            meta_schemas[cls.META_SCHEMA[u"$id"]] = cls
         return cls
     return _validates
 


### PR DESCRIPTION
Fix another spot where 'id' vs. '$id' needs to be handled for draft 6+.

Signed-off-by: Grant Likely <grant.likely@arm.com>
[robh: re-word commit message]
Signed-off-by: Rob Herring <robh@kernel.org>