### PR TITLE
add parameter checking to checks()

### DIFF
--- a/jsonschema/_format.py
+++ b/jsonschema/_format.py
@@ -60,6 +60,12 @@ class FormatChecker(object):
         """
 
         def _checks(func):
+            if not isinstance(format, str_types):
+                raise FormatError('specified format %s is not a string'
+                                  % format)
+            if not callable(func):
+                raise FormatError('specified function %s is not callable'
+                                  % func)
             self.checkers[format] = (func, raises)
             return func
         return _checks

--- a/jsonschema/tests/test_format.py
+++ b/jsonschema/tests/test_format.py
@@ -62,3 +62,8 @@ class TestFormatChecker(TestCase):
             validator.validate("bar")
 
         self.assertIs(cm.exception.__cause__, cause)
+
+    def test_bad_args(self):
+        checker = FormatChecker()
+        func = checker.checks(self.fn, raises=ValueError)
+        self.assertRaises(FormatError, func, "foo")


### PR DESCRIPTION
Currently, we don't check that the arguments to checks() are actually a
string and a function (in that order). It's easy to reverse the order of
arguments, which leads to silent failure because the function is not a
match when we do a key lookup in self.checkers.

Fix this by validating the paramaters to checks().