### PR TITLE
functools32 into extra requires

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,11 @@ _static
 _templates
 
 TODO
+
+.eggs/
+.tox/
+_trial_temp/
+build/
+*.egg-info/
+__pycache__/
+*.pyc

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,11 @@ setup(
         "attrs>=17.4.0",
         "pyrsistent>=0.14.0",
         "six>=1.11.0",
-        "functools32;python_version<'3'",
     ],
     extras_require={
+        ":python_version<'3.2'": [
+            "functools32",
+        ],
         "format": [
             "jsonpointer>1.13",
             "rfc3987",


### PR DESCRIPTION
The goal of this PR is to maintain support of older versions of pip/setuptools while maintaining the conditional `functools32` dependency.
