### PR TITLE
Fix unclosed resource in validators

### DIFF
--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -1199,8 +1199,8 @@ class TestRefResolver(TestCase):
                     self.assertEqual(resolved, 12)
 
         urlopen_mock.assert_called_once_with("http://bar")
-        resource_manager_mock.__enter__.assert_called_once()
-        resource_manager_mock.__exit__.assert_called_once()
+        self.assertEqual(resource_manager_mock.__enter__.call_count, 1)
+        self.assertEqual(resource_manager_mock.__exit__.call_count, 1)
 
     def test_it_can_construct_a_base_uri_from_a_schema(self):
         schema = {"id": "foo"}

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -1199,8 +1199,8 @@ class TestRefResolver(TestCase):
                     self.assertEqual(resolved, 12)
 
         urlopen_mock.assert_called_once_with("http://bar")
-        self.assertEqual(resource_manager_mock.__enter__.call_count, 1)
         self.assertEqual(resource_manager_mock.__exit__.call_count, 1)
+        self.assertEqual(resource_manager_mock.__enter__.call_count, 1)
 
     def test_it_can_construct_a_base_uri_from_a_schema(self):
         schema = {"id": "foo"}

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -1199,10 +1199,8 @@ class TestRefResolver(TestCase):
                     self.assertEqual(resolved, 12)
 
         urlopen_mock.assert_called_once_with("http://bar")
-        self.assertIn(mock.call.__enter__(),
-                      resource_manager_mock.mock_calls)
-        self.assertIn(mock.call.__exit__(None, None, None),
-                      resource_manager_mock.mock_calls)
+        resource_manager_mock.__enter__.assert_called_once()
+        resource_manager_mock.__exit__.assert_called_once()
 
     def test_it_can_construct_a_base_uri_from_a_schema(self):
         schema = {"id": "foo"}

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -753,7 +753,8 @@ class RefResolver(object):
                 result = requests.get(uri).json
         else:
             # Otherwise, pass off to urllib and assume utf-8
-            result = json.loads(urlopen(uri).read().decode("utf-8"))
+            with urlopen(uri) as url:
+                result = json.loads(url.read().decode("utf-8"))
 
         if self.cache_remote:
             self.store[uri] = result


### PR DESCRIPTION
The resource used by `urlopen` was never explicitly closed, running an app with pythons `-W all` flag raised loads of `ResourceWarning`s. Using a context manager is a simple fix.