### PR TITLE
Use context managers instead of unrolled scopes

### DIFF
--- a/jsonschema/_utils.py
+++ b/jsonschema/_utils.py
@@ -15,7 +15,8 @@ class URIDict(MutableMapping):
 
     def normalize(self, uri):
         result = urisplit(uri)
-        return uriunsplit((result.scheme, result.authority, result.path, None, None))
+        return uriunsplit((result.scheme, result.authority,
+                           result.path, None, None))
 
     def __init__(self, *args, **kwargs):
         self.store = dict()

--- a/jsonschema/_utils.py
+++ b/jsonschema/_utils.py
@@ -4,7 +4,7 @@ import pkgutil
 import re
 
 from jsonschema.compat import str_types, MutableMapping
-from uritools import urisplit
+from uritools import urisplit, uriunsplit
 
 
 class URIDict(MutableMapping):
@@ -14,7 +14,8 @@ class URIDict(MutableMapping):
     """
 
     def normalize(self, uri):
-        return urisplit(uri).geturi()
+        result = urisplit(uri)
+        return uriunsplit((result.scheme, result.authority, result.path, None, None))
 
     def __init__(self, *args, **kwargs):
         self.store = dict()

--- a/jsonschema/_utils.py
+++ b/jsonschema/_utils.py
@@ -3,7 +3,8 @@ import json
 import pkgutil
 import re
 
-from jsonschema.compat import str_types, MutableMapping, urlsplit
+from jsonschema.compat import str_types, MutableMapping
+from uritools import urisplit
 
 
 class URIDict(MutableMapping):
@@ -13,7 +14,7 @@ class URIDict(MutableMapping):
     """
 
     def normalize(self, uri):
-        return urlsplit(uri).geturl()
+        return urisplit(uri).getpath()
 
     def __init__(self, *args, **kwargs):
         self.store = dict()

--- a/jsonschema/_utils.py
+++ b/jsonschema/_utils.py
@@ -14,7 +14,7 @@ class URIDict(MutableMapping):
     """
 
     def normalize(self, uri):
-        return urisplit(uri).getpath()
+        return urisplit(uri).geturi()
 
     def __init__(self, *args, **kwargs):
         self.store = dict()

--- a/jsonschema/_validators.py
+++ b/jsonschema/_validators.py
@@ -301,20 +301,9 @@ def enum(validator, enums, instance, schema):
 
 
 def ref(validator, ref, instance, schema):
-    resolve = getattr(validator.resolver, "resolve", None)
-    if resolve is None:
-        with validator.resolver.resolving(ref) as resolved:
-            for error in validator.descend(instance, resolved):
-                yield error
-    else:
-        scope, resolved = validator.resolver.resolve(ref)
-        validator.resolver.push_scope(scope)
-
-        try:
-            for error in validator.descend(instance, resolved):
-                yield error
-        finally:
-            validator.resolver.pop_scope()
+    with validator.resolver.resolving(ref) as resolved:
+        for error in validator.descend(instance, resolved):
+            yield error
 
 
 def type_draft3(validator, types, instance, schema):

--- a/jsonschema/compat.py
+++ b/jsonschema/compat.py
@@ -14,7 +14,7 @@ if PY3:
     from functools import lru_cache
     from io import StringIO
     from urllib.parse import (
-        unquote, urljoin, urlunsplit, SplitResult, urlsplit as _urlsplit
+        unquote, urljoin, urlunsplit, SplitResult
     )
     from urllib.request import urlopen
     str_types = str,
@@ -24,7 +24,7 @@ else:
     from itertools import izip as zip  # noqa
     from StringIO import StringIO
     from urlparse import (
-        urljoin, urlunsplit, SplitResult, urlsplit as _urlsplit # noqa
+        urljoin, urlunsplit, SplitResult # noqa
     )
     from urllib import unquote  # noqa
     from urllib2 import urlopen  # noqa
@@ -33,24 +33,5 @@ else:
     iteritems = operator.methodcaller("iteritems")
 
     from functools32 import lru_cache
-
-
-# On python < 3.3 fragments are not handled properly with unknown schemes
-def urlsplit(url):
-    scheme, netloc, path, query, fragment = _urlsplit(url)
-    if "#" in path:
-        path, fragment = path.split("#", 1)
-    return SplitResult(scheme, netloc, path, query, fragment)
-
-
-def urldefrag(url):
-    if "#" in url:
-        s, n, p, q, frag = urlsplit(url)
-        defrag = urlunsplit((s, n, p, q, ''))
-    else:
-        defrag = url
-        frag = ''
-    return defrag, frag
-
 
 # flake8: noqa

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -1217,7 +1217,7 @@ class TestRefResolver(TestCase):
                     self.assertEqual(resolved, 12)
         requests.Session().get.assert_called_once_with("file://bar.json")
 
-    def test_it_retrieves_unstored_refs_via_urlopen_without_requests_file(self):
+    def test_it_retrieves_unstored_refs_via_urlopen_no_requests_file(self):
         ref = "file://bar.json#baz"
         schema = {"baz": 12}
 

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -870,12 +870,11 @@ class ValidatorTestMixin(object):
         resolver = validators.RefResolver("", {})
         schema = {"$ref": mock.Mock()}
 
-        with mock.patch.object(resolver, "resolve") as resolve:
-            resolve.return_value = "url", {"type": "integer"}
+        with mock.patch.object(resolver, "resolving") as resolving:
+            resolving.return_value.__enter__.return_value = {"type": "integer"}
             with self.assertRaises(ValidationError):
                 self.validator_class(schema, resolver=resolver).validate(None)
-
-        resolve.assert_called_once_with(schema["$ref"])
+        resolving.assert_called_once_with(schema["$ref"])
 
     def test_it_delegates_to_a_legacy_ref_resolver(self):
         """
@@ -885,6 +884,10 @@ class ValidatorTestMixin(object):
         """
 
         class LegacyRefResolver(object):
+            @contextmanager
+            def in_scope(self, scope):
+                yield
+
             @contextmanager
             def resolving(this, ref):
                 self.assertEqual(ref, "the ref")

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -1201,12 +1201,13 @@ class TestRefResolver(TestCase):
 
         with MockImport("requests", None):
             with mock.patch("jsonschema.validators.urlopen") as urlopen:
-                urlopen.return_value.read.return_value = (json.dumps(schema).encode("utf8"))
+                urlopen.return_value.read.return_value = (
+                    json.dumps(schema).encode("utf8"))
                 with self.resolver.resolving(ref) as resolved:
                     self.assertEqual(resolved, 12)
         urlopen.assert_called_once_with("file://bar.json")
 
-    def test_it_retrieves_unstored_file_refs_via_requests_and_requests_file(self):
+    def test_it_retrieves_unstored_file_refs_via_requests_file(self):
         ref = "file://bar.json#baz"
         schema = {"baz": 12}
 

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -1217,7 +1217,7 @@ class TestRefResolver(TestCase):
                     self.assertEqual(resolved, 12)
         requests.Session().get.assert_called_once_with("file://bar.json")
 
-    def test_it_retrieves_unstored_refs_via_urlopen_when_requests_file_missing(self):
+    def test_it_retrieves_unstored_refs_via_urlopen_without_requests_file(self):
         ref = "file://bar.json#baz"
         schema = {"baz": 12}
 

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -1178,10 +1178,10 @@ class TestRefResolver(TestCase):
         schema = {"baz": 12}
 
         with MockImport("requests", mock.Mock()) as requests:
-            requests.get.return_value.json.return_value = schema
+            requests.Session.get.return_value.json.return_value = schema
             with self.resolver.resolving(ref) as resolved:
                 self.assertEqual(resolved, 12)
-        requests.get.assert_called_once_with("http://bar")
+        requests.Session().get.assert_called_once_with("http://bar")
 
     def test_it_retrieves_unstored_refs_via_urlopen(self):
         ref = "http://bar#baz"

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -1211,7 +1211,7 @@ class TestRefResolver(TestCase):
         schema = {"baz": 12}
 
         with MockImport("requests", mock.Mock()) as requests:
-            with MockImport("requests_file", mock.Mock()) as requests_file:
+            with MockImport("requests_file", mock.Mock()):
                 requests.Session.get.return_value.json.return_value = schema
                 with self.resolver.resolving(ref) as resolved:
                     self.assertEqual(resolved, 12)

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -694,7 +694,7 @@ class RefResolver(object):
             except Exception as exc:
                 raise RefResolutionError(exc)
 
-        return self.resolve_fragment(document, fragment)
+        return self.resolve_fragment(document, fragment or '')
 
     def resolve_fragment(self, document, fragment):
         """

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -531,7 +531,7 @@ class RefResolver(object):
         remote_cache (functools.lru_cache):
 
             A cache that will be used for caching the results of
-            resolved remote URLs.
+            resolved remote URIs.
 
     Attributes:
 
@@ -554,7 +554,7 @@ class RefResolver(object):
         if urijoin_cache is None:
             urijoin_cache = lru_cache(1024)(urijoin)
         if remote_cache is None:
-            remote_cache = lru_cache(1024)(self.resolve_from_url)
+            remote_cache = lru_cache(1024)(self.resolve_from_uri)
 
         self.referrer = referrer
         self.cache_remote = cache_remote
@@ -673,24 +673,24 @@ class RefResolver(object):
 
         """
 
-        url, resolved = self.resolve(ref)
-        self.push_scope(url)
+        uri, resolved = self.resolve(ref)
+        self.push_scope(uri)
         try:
             yield resolved
         finally:
             self.pop_scope()
 
     def resolve(self, ref):
-        url = self._urijoin_cache(self.resolution_scope, ref)
-        return url, self._remote_cache(url)
+        uri = self._urijoin_cache(self.resolution_scope, ref)
+        return uri, self._remote_cache(uri)
 
-    def resolve_from_url(self, url):
-        url, fragment = uridefrag(url)
+    def resolve_from_uri(self, uri):
+        uri, fragment = uridefrag(uri)
         try:
-            document = self.store[url]
+            document = self.store[uri]
         except KeyError:
             try:
-                document = self.resolve_remote(url)
+                document = self.resolve_remote(uri)
             except Exception as exc:
                 raise RefResolutionError(exc)
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "pyrsistent>=0.14.0",
         "six>=1.11.0",
         "functools32;python_version<'3'",
-        "uritools>=2.2.0"
+        "uritools>=2.2.0",
     ],
     extras_require={
         "format": [

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         "pyrsistent>=0.14.0",
         "six>=1.11.0",
         "functools32;python_version<'3'",
+        "uritools>=2.2.0"
     ],
     extras_require={
         "format": [


### PR DESCRIPTION
Depends upon GH-428.

I've seen #158 which suggests that this is a deliberate feature. Perhaps then this isn't appropriate.

However, in https://github.com/agoose77/jsonschema/blob/master/jsonschema/_validators.py#L304 we have more complicated logic where we look for the contextmanager, and use it if available, otherwise defaulting to an unrolled loop. As far as I can tell, this is to facilitate the mock ref resolver which only provides the context manager. If performance is still a concern, I suggest we eliminate one branch.