### PR TITLE
Fix bug in current registration of validators and address #417

### DIFF
--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -1030,6 +1030,7 @@ class TestValidatorFor(TestCase):
         Validator = validators.create(
             meta_schema={"id": "meta schema id"},
             version="12",
+            id_of=lambda s: s.get("id", ""),
         )
         schema = {"$schema": "meta schema id"}
         self.assertIs(

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -52,8 +52,9 @@ def validates(version):
 
     def _validates(cls):
         validators[version] = cls
-        if u"id" in cls.META_SCHEMA:
-            meta_schemas[cls.META_SCHEMA[u"id"]] = cls
+        meta_schema_id = cls.ID_OF(cls.META_SCHEMA)
+        if meta_schema_id:
+            meta_schemas[meta_schema_id] = cls
         return cls
     return _validates
 
@@ -204,6 +205,7 @@ def create(
         VALIDATORS = dict(validators)
         META_SCHEMA = dict(meta_schema)
         TYPE_CHECKER = type_checker
+        ID_OF = staticmethod(id_of)
 
         _DEFAULT_TYPES = dict(default_types)
 


### PR DESCRIPTION
Alternative solution to #417 (fixes #417) 
Currently, the validator registration is hardcoded to use the deprecated "id" keyword, rather than using the new "id_of" function passed to `create`. This means that only draft 3 and 4 are currently registered. This is not visibly a bug at present, because there is only one other schema, and the fallback mechanism selects the most recent. However, for good practice we should still register the draft 6 schema.

This PR adds a `Validator.ID_OF` staticmethod, and call it from the registrar.