### PR TITLE
The `validates` decorator is not needed in the current form.

### DIFF
--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -62,17 +62,16 @@ class TestCreateAndExtend(TestCase):
         )
 
     def test_if_a_version_is_provided_it_is_registered(self):
-        with mock.patch("jsonschema.validators.validates") as validates:
-            validates.side_effect = lambda version: lambda cls: cls
+        with mock.patch("jsonschema.validators.register_validator") as validates:
             Validator = validators.create(
                 meta_schema={u"id": ""},
                 version="my version",
             )
-        validates.assert_called_once_with("my version")
+        validates.assert_called_once_with("my version", Validator)
         self.assertEqual(Validator.__name__, "MyVersionValidator")
 
     def test_if_a_version_is_not_provided_it_is_not_registered(self):
-        with mock.patch("jsonschema.validators.validates") as validates:
+        with mock.patch("jsonschema.validators.register_validator") as validates:
             validators.create(meta_schema={u"id": "id"})
         self.assertFalse(validates.called)
 

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -31,6 +31,12 @@ validators = {}
 meta_schemas = _utils.URIDict()
 
 
+def register_validator(version, cls):
+    validators[version] = cls
+    if u"id" in cls.META_SCHEMA:
+        meta_schemas[cls.META_SCHEMA[u"id"]] = cls
+
+
 def validates(version):
     """
     Register the decorated validator for a ``version`` of the specification.
@@ -51,9 +57,7 @@ def validates(version):
     """
 
     def _validates(cls):
-        validators[version] = cls
-        if u"id" in cls.META_SCHEMA:
-            meta_schemas[cls.META_SCHEMA[u"id"]] = cls
+        register_validator(version, cls)
         return cls
     return _validates
 
@@ -307,7 +311,7 @@ def create(
             return error is None
 
     if version is not None:
-        Validator = validates(version)(Validator)
+        register_validator(version, Validator)
         Validator.__name__ = version.title().replace(" ", "") + "Validator"
 
     return Validator


### PR DESCRIPTION
Instead, create a new function `register_validator` which is called from `validates`.
Test `register_validator` instead of `validates`, and deprecate `validates` use internally.