### PR TITLE
Use RFC3986 instead of manual string parsing

### DIFF
--- a/jsonschema/_utils.py
+++ b/jsonschema/_utils.py
@@ -3,7 +3,7 @@ import json
 import pkgutil
 import re
 
-from jsonschema.compat import str_types, MutableMapping, urlsplit
+from jsonschema.compat import str_types, MutableMapping
 
 
 class URIDict(MutableMapping):
@@ -13,7 +13,9 @@ class URIDict(MutableMapping):
     """
 
     def normalize(self, uri):
-        return urlsplit(uri).geturl()
+        normalized = uri.normalize()
+        assert not normalized.fragment, "URI had unexpected non-empty fragment"
+        return normalized.copy_with(fragment=None)
 
     def __init__(self, *args, **kwargs):
         self.store = dict()

--- a/jsonschema/compat.py
+++ b/jsonschema/compat.py
@@ -13,9 +13,6 @@ if PY3:
     zip = zip
     from functools import lru_cache
     from io import StringIO
-    from urllib.parse import (
-        unquote, urljoin, urlunsplit, SplitResult, urlsplit as _urlsplit
-    )
     from urllib.request import urlopen
     str_types = str,
     int_types = int,
@@ -23,9 +20,6 @@ if PY3:
 else:
     from itertools import izip as zip  # noqa
     from StringIO import StringIO
-    from urlparse import (
-        urljoin, urlunsplit, SplitResult, urlsplit as _urlsplit # noqa
-    )
     from urllib import unquote  # noqa
     from urllib2 import urlopen  # noqa
     str_types = basestring
@@ -33,24 +27,6 @@ else:
     iteritems = operator.methodcaller("iteritems")
 
     from functools32 import lru_cache
-
-
-# On python < 3.3 fragments are not handled properly with unknown schemes
-def urlsplit(url):
-    scheme, netloc, path, query, fragment = _urlsplit(url)
-    if "#" in path:
-        path, fragment = path.split("#", 1)
-    return SplitResult(scheme, netloc, path, query, fragment)
-
-
-def urldefrag(url):
-    if "#" in url:
-        s, n, p, q, frag = urlsplit(url)
-        defrag = urlunsplit((s, n, p, q, ''))
-    else:
-        defrag = url
-        frag = ''
-    return defrag, frag
 
 
 # flake8: noqa

--- a/jsonschema/compat.py
+++ b/jsonschema/compat.py
@@ -18,6 +18,9 @@ if PY3:
     str_types = str,
     int_types = int,
     iteritems = operator.methodcaller("items")
+
+    import rfc3986
+    rfc3986.URIReference.__hash__ = tuple.__hash__
 else:
     from itertools import izip as zip  # noqa
     from StringIO import StringIO

--- a/jsonschema/compat.py
+++ b/jsonschema/compat.py
@@ -13,6 +13,7 @@ if PY3:
     zip = zip
     from functools import lru_cache
     from io import StringIO
+    from urllib.parse import unquote
     from urllib.request import urlopen
     str_types = str,
     int_types = int,

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -79,7 +79,9 @@ class TestCreateAndExtend(TestCase):
 
     def test_validates_registers_meta_schema_id(self):
         my_meta_schema = {u"id": "meta schema id"}
-        id_of = lambda s: uri_reference(s.get("id", ""))
+
+        def id_of(schema):
+            return uri_reference(schema.get("id", ""))
 
         validators.create(
             meta_schema=my_meta_schema,

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -113,7 +113,7 @@ def _as_uri(uri_or_str):
     """Return URIReference parse result of input string,
     or pass through URIReference argument
     """
-    if isinstance(uri_or_str, basestring):
+    if isinstance(uri_or_str, str_types):
         return uri_reference(uri_or_str)
     return uri_or_str
 
@@ -583,7 +583,7 @@ class RefResolver(object):
         if remote_cache is None:
             remote_cache = lru_cache(1024)(self.resolve_from_url)
 
-        if isinstance(base_uri, basestring):
+        if isinstance(base_uri, str_types):
             base_uri = uri_reference(base_uri)
 
         if not base_uri.unsplit():

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -134,7 +134,7 @@ def _load_uri_from_schema(schema, key):
 
 def _id_of(schema):
     if schema is True or schema is False:
-        return u""
+        return uri_reference("")
     return _load_uri_from_schema(schema, "$id")
 
 

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -6,7 +6,7 @@ import json
 import numbers
 
 from six import add_metaclass
-from rfc3986 import uri_reference
+from rfc3986 import uri_reference, URIReference
 
 from jsonschema import _utils, _validators, _types
 from jsonschema.compat import (

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -110,7 +110,8 @@ class _DefaultTypesDeprecatingMetaClass(type):
 
 
 def _as_uri(uri_or_str):
-    """Return URIReference parse result of input string,
+    """
+    Return URIReference parse result of input string,
     or pass through URIReference argument
     """
     if isinstance(uri_or_str, str_types):
@@ -124,7 +125,8 @@ def _join_uri(base, ref):
 
 
 def _load_uri_from_schema(schema, key):
-    """Return URIReference object from URI given by key in schema.
+    """
+    Return URIReference object from URI given by key in schema.
     Return URIReference.fromstring('') if key not found
     """
     return uri_reference(schema.get(key, ""))

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         "pyrsistent>=0.14.0",
         "six>=1.11.0",
         "functools32;python_version<'3'",
+        "rfc3986>=1.1.0",
     ],
     extras_require={
         "format": [


### PR DESCRIPTION
This PR moves from using `urllib2`/`urlparse` to `rfc3986` to perform URI handling. Parsed URI objects are now handled internally (and exposed from the public `RefResolver` attributes, but strings may be passed in to the `RefResolver` public API as before. Some tests needed to be changed to reflect the more strict of URIs (such as the base URI must be absolute, or a URI reference with an empty fragment). Furthermore, an empty-string URI is not valid by the above rule, so a null URN is used. This probably should be a locatable URI (e.g file) rather than a URN upon reflection.

Originally it was discussed (#346) that `hyperlink` would be the candidate library for better handling of URIs. After implementing support for `hyperlink`, it slows the test-suite by approximately 8-9 X (from 1-2s to 17-18s). I then chose to use the `rfc3986` library, and then implemented a new branch which replaces the `rfc3986` api with the largely similar one of `hyperlink`, just so you can actually run the test suite with both `hyperlink` and `rfc3986`. It may well be that I've missed something related to caching that I'm not aware of, which explains why the `hyperlink` implementation is so slow. 

The minor differences between the `rfc3986_patch` and the [`rfc_to_hyper`](https://github.com/agoose77/jsonschema/tree/rfc_to_hyper) branches, besides the different APIs, are partly that `hyperlink` doesn't support resolving against rootless URIs, so a rooted default URI has to be used. Also, the `rfc3986` parsed URI object defines a method for string comparison, whereas `hyperlink` does not.

Of the libraries investigated.
* `hyperlink` slow, immutable
* `furl` slow, muteable
* `rfc3987` immutable, not tested (doesn't implement normalisation yet)
* `rfc3896` fastest and immutable objects