### PR TITLE
jsonschema: Fix non http/https url RefResolution exception

### DIFF
--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -755,8 +755,8 @@ class RefResolver(object):
                 result = requests.get(uri).json
         else:
             # Otherwise, pass off to urllib and assume utf-8
-            with urlopen(uri) as url:
-                result = json.loads(url.read().decode("utf-8"))
+            url = urlopen(uri)
+            result = json.loads(url.read().decode("utf-8"))
 
         if self.cache_remote:
             self.store[uri] = result


### PR DESCRIPTION
When using file:///schema-dir-name URLs we are hitting AttributeError
exception during refresolution. Reason for it is, there isn't any
context manager implemented for urlopen (i.e. it doesn't have
__enter__ and __exit__ methods defined).

This patch fixes this issue.

Signed-off-by: Kuppuswamy Sathyanarayanan <sathyaosid@gmail.com>