### PR TITLE
Add referrer to handler's call

### DIFF
--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -1327,11 +1327,10 @@ class TestRefResolver(TestCase):
             "", referrer, handlers={"file": file_handler}
         )
         with resolver.resolving(ref):
-            key, resolved = resolver.resolve(ref)
+            pass
 
-        # Why is it this, really?
-        self.assertEqual('schemas/common.json', key)
-        self.assertEqual(expected, resolved)
+        self.assertTrue(ref in resolver.store)
+        self.assertEqual(resolver.store[ref], expected)
 
 
 class UniqueTupleItemsMixin(object):

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -541,6 +541,8 @@ class RefResolver(object):
             Whether remote refs should be cached after first resolution
 
     """
+    default_scheme = 'file'
+    """ If urlsplit() does not find a scheme, we use this one. """
 
     def __init__(
         self,
@@ -739,9 +741,11 @@ class RefResolver(object):
             requests = None
 
         scheme = urlsplit(uri).scheme
+        if not scheme:
+            scheme = self.default_scheme
 
         if scheme in self.handlers:
-            result = self.handlers[scheme](uri)
+            result = self.handlers[scheme](uri, referrer=self.referrer)
         elif (
             scheme in [u"http", u"https"] and
             requests and


### PR DESCRIPTION
For handlers to resolve relative references, they need a referrer to be
passed in.

Looking at the code and tests especially I'm starting to doubt if this was the intent of the referrer argument. It can be used in this way, but what resolver.resolve() returns as first member of the tuple is a bit magical to me. However, we do need a way to be able to resolve relative references.

The code also introduces a default scheme, with a default conforming to what is normal in the URI resolver world.