### PR TITLE
Fix infinite recursion in TypeChecker example

### DIFF
--- a/docs/validate.rst
+++ b/docs/validate.rst
@@ -213,7 +213,7 @@ existing `TypeChecker` or create a new one. You may then create a new
 
     def is_my_int(checker, instance):
         return (
-            checker.is_type(instance, "number") or
+            Draft3Validator.TYPE_CHECKER.is_type(instance, "number") or
             isinstance(instance, MyInteger)
         )
 


### PR DESCRIPTION
Fixes the following copied almost verbatim from the docs:
```python
>>> from jsonschema import Draft3Validator
... from jsonschema.validators import extend
... class MyInteger(object):
...     pass
...
... def is_my_int(checker, instance):
...     return (
...         checker.is_type(instance, "number") or
...         isinstance(instance, MyInteger)
...     )
...
... type_checker = Draft3Validator.TYPE_CHECKER.redefine("number", is_my_int)
...
... CustomValidator = extend(Draft3Validator, type_checker=type_checker)
... validator = CustomValidator(schema={"type" : "number"})
... validator.validate({})
```

which results in an infinite recursion:
```python
...
  File "/tmp/env/lib/python2.7/site-packages/jsonschema/_types.py", line 95, in is_type
    return fn(self, instance)
  File "<stdin>", line 8, in is_my_int
  File "/tmp/env/lib/python2.7/site-packages/jsonschema/_types.py", line 91, in is_type
    fn = self._type_checkers[type]
  File "/tmp/env/lib/python2.7/site-packages/pyrsistent/_pmap.py", line 71, in __getitem__
    return PMap._getitem(self._buckets, key)
RuntimeError: maximum recursion depth exceeded
maximum recursion depth exceeded
```