### PR TITLE
Return the instance from `validate`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ for Python (supporting 2.7+ including Python 3).
 
     >>> # If no exception is raised by validate(), the instance is valid.
     >>> validate({"name" : "Eggs", "price" : 34.99}, schema)
-    {"name" : "Eggs", "price" : 34.99}
+    {'name' : 'Eggs', 'price' : 34.99}
 
     >>> validate(
     ...     {"name" : "Eggs", "price" : "Invalid"}, schema

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ for Python (supporting 2.7+ including Python 3).
 
     >>> # If no exception is raised by validate(), the instance is valid.
     >>> validate({"name" : "Eggs", "price" : 34.99}, schema)
-    {'name' : 'Eggs', 'price' : 34.99}
+    {'name': 'Eggs', 'price' : 34.99}
 
     >>> validate(
     ...     {"name" : "Eggs", "price" : "Invalid"}, schema

--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,7 @@ for Python (supporting 2.7+ including Python 3).
 
     >>> # If no exception is raised by validate(), the instance is valid.
     >>> validate({"name" : "Eggs", "price" : 34.99}, schema)
+    {"name" : "Eggs", "price" : 34.99}
 
     >>> validate(
     ...     {"name" : "Eggs", "price" : "Invalid"}, schema

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ for Python (supporting 2.7+ including Python 3).
 
     >>> # If no exception is raised by validate(), the instance is valid.
     >>> validate({"name" : "Eggs", "price" : 34.99}, schema)
-    {'name': 'Eggs', 'price' : 34.99}
+    {'name': 'Eggs', 'price': 34.99}
 
     >>> validate(
     ...     {"name" : "Eggs", "price" : "Invalid"}, schema

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -812,6 +812,9 @@ def validate(instance, schema, cls=None, *args, **kwargs):
         `jsonschema.exceptions.SchemaError` if the schema itself
             is invalid
 
+    Returns:
+        The instance.
+
     .. rubric:: Footnotes
     .. [#] known by a validator registered with
         `jsonschema.validators.validates`
@@ -820,6 +823,7 @@ def validate(instance, schema, cls=None, *args, **kwargs):
         cls = validator_for(schema)
     cls.check_schema(schema)
     cls(schema, *args, **kwargs).validate(instance)
+    return instance
 
 
 def validator_for(schema, default=_LATEST_VERSION):


### PR DESCRIPTION
The validate function currently returns None. Returning the instance
allows the user to use validate in a function chain, for example:

```python
try:
    return process(validate(deserialize(string)))
except jsonschema.ValidationError:
    ...
```