### PR TITLE
Prefer importing ABCs from collections.abc

### DIFF
--- a/jsonschema/compat.py
+++ b/jsonschema/compat.py
@@ -3,9 +3,9 @@ import sys
 
 
 try:
-    from collections import MutableMapping, Sequence  # noqa
-except ImportError:
     from collections.abc import MutableMapping, Sequence  # noqa
+except ImportError:
+    from collections import MutableMapping, Sequence  # noqa
 
 PY3 = sys.version_info[0] >= 3
 


### PR DESCRIPTION
"`from collections import MutableMapping, Sequence`" produces a `DeprecationWarning` under Python 3.7 with the message:

> Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working

This patch eliminates this warning by preferring to import from `collections.abc` first, falling back to `collections` only if that fails (i.e., if running under Python < 3.3).