### PR TITLE
Add a deprecation warning to validate_for if schema doesn't exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ _static
 _templates
 
 TODO
+.venv
+.tox

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,3 @@ _static
 _templates
 
 TODO
-.venv
-.tox

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -1198,8 +1198,8 @@ class TestValidatorFor(SynchronousTestCase):
         self.assertWarns(
             category=DeprecationWarning,
             message=(
-                "This metaschema was not found but going to validate with latest draft. "
-                "This will raise an error in future. "
+                "This metaschema was not found but going to validate with the "
+                "latest draft. This will raise an error in future. "
             ),
             # https://tm.tl/9363 :'(
             filename=sys.modules[self.assertWarns.__module__].__file__,
@@ -1214,7 +1214,9 @@ class TestValidatorFor(SynchronousTestCase):
         self.assertFalse(self.flushWarnings())
 
     def test_latest_schema_used_if_meta_schema_not_specified(self):
-        lastestSchema = validators.meta_schemas["http://json-schema.org/draft-07/schema#"]
+        lastestSchema = validators.meta_schemas[
+            "http://json-schema.org/draft-07/schema#"
+        ]
         schema = validators.validator_for(schema={}, default=lastestSchema)
         self.assertEqual(schema, lastestSchema)
 

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -8,7 +8,6 @@ import os
 import sys
 import tempfile
 import unittest
-import warnings
 
 from twisted.trial.unittest import SynchronousTestCase
 import attr

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -1194,7 +1194,7 @@ class TestValidatorFor(SynchronousTestCase):
     def test_validator_for_custom_default(self):
         self.assertIs(validators.validator_for({}, default=None), None)
 
-    def test_validator_warns_if_schema_not_found(self):
+    def test_warns_if_schema_specified_not_in_meta_schema(self):
         self.assertWarns(
             category=DeprecationWarning,
             message=(
@@ -1205,9 +1205,18 @@ class TestValidatorFor(SynchronousTestCase):
             filename=sys.modules[self.assertWarns.__module__].__file__,
 
             f=validators.validator_for,
-            schema={},
+            schema={u"$schema": 'unknownSchema'},
             default={},
         )
+
+    def test_doesnt_warns_if_schema_not_specified(self):
+        validators.validator_for(schema={}, default={}),
+        self.assertFalse(self.flushWarnings())
+
+    def test_latest_schema_used_if_schema_not_specified(self):
+        lastestSchema = validators.meta_schemas["http://json-schema.org/draft-07/schema#"]
+        schema = validators.validator_for(schema={}, default=lastestSchema)
+        self.assertEqual(schema, lastestSchema)
 
 
 class TestValidate(TestCase):

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -1199,7 +1199,7 @@ class TestValidatorFor(SynchronousTestCase):
             category=DeprecationWarning,
             message=(
                 "This schema was not found but going to validate with latest draft. "
-                "This will raise a SchemaError in future. "
+                "This will raise an error in future. "
             ),
             # https://tm.tl/9363 :'(
             filename=sys.modules[self.assertWarns.__module__].__file__,

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -1198,7 +1198,7 @@ class TestValidatorFor(SynchronousTestCase):
         self.assertWarns(
             category=DeprecationWarning,
             message=(
-                "This schema: unknownSchema was not found but going to validate with latest draft. "
+                "This metaschema was not found but going to validate with latest draft. "
                 "This will raise an error in future. "
             ),
             # https://tm.tl/9363 :'(

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -1194,11 +1194,11 @@ class TestValidatorFor(SynchronousTestCase):
     def test_validator_for_custom_default(self):
         self.assertIs(validators.validator_for({}, default=None), None)
 
-    def test_warns_if_schema_specified_not_in_meta_schema(self):
+    def test_warns_if_meta_schema_specified_was_not_found(self):
         self.assertWarns(
             category=DeprecationWarning,
             message=(
-                "This schema was not found but going to validate with latest draft. "
+                "This schema: unknownSchema was not found but going to validate with latest draft. "
                 "This will raise an error in future. "
             ),
             # https://tm.tl/9363 :'(
@@ -1209,11 +1209,11 @@ class TestValidatorFor(SynchronousTestCase):
             default={},
         )
 
-    def test_doesnt_warns_if_schema_not_specified(self):
+    def test_doesnt_warns_if_meta_schema_not_specified(self):
         validators.validator_for(schema={}, default={}),
         self.assertFalse(self.flushWarnings())
 
-    def test_latest_schema_used_if_schema_not_specified(self):
+    def test_latest_schema_used_if_meta_schema_not_specified(self):
         lastestSchema = validators.meta_schemas["http://json-schema.org/draft-07/schema#"]
         schema = validators.validator_for(schema={}, default=lastestSchema)
         self.assertEqual(schema, lastestSchema)

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -8,6 +8,7 @@ import os
 import sys
 import tempfile
 import unittest
+import warnings
 
 from twisted.trial.unittest import SynchronousTestCase
 import attr
@@ -1100,7 +1101,7 @@ for format in FormatChecker.checkers:
     setattr(TestBuiltinFormats, name, test)
 
 
-class TestValidatorFor(TestCase):
+class TestValidatorFor(SynchronousTestCase):
     def test_draft_3(self):
         schema = {"$schema": "http://json-schema.org/draft-03/schema"}
         self.assertIs(
@@ -1191,8 +1192,24 @@ class TestValidatorFor(TestCase):
     def test_validator_for_jsonschema_default(self):
         self.assertIs(validators.validator_for({}), validators._LATEST_VERSION)
 
+
     def test_validator_for_custom_default(self):
         self.assertIs(validators.validator_for({}, default=None), None)
+
+    def test_validator_warns_if_schema_not_found(self):
+        self.assertWarns(
+            category=DeprecationWarning,
+            message=(
+                "This schema was not found but going to validate with latest draft. "
+                "This will raise a SchemaError in future. "
+            ),
+            # https://tm.tl/9363 :'(
+            filename=sys.modules[self.assertWarns.__module__].__file__,
+
+            f=validators.validator_for,
+            schema={},
+            default={}
+        )
 
 
 class TestValidate(TestCase):

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -1206,7 +1206,7 @@ class TestValidatorFor(SynchronousTestCase):
 
             f=validators.validator_for,
             schema={},
-            default={}
+            default={},
         )
 
 

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -1191,7 +1191,6 @@ class TestValidatorFor(SynchronousTestCase):
     def test_validator_for_jsonschema_default(self):
         self.assertIs(validators.validator_for({}), validators._LATEST_VERSION)
 
-
     def test_validator_for_custom_default(self):
         self.assertIs(validators.validator_for({}, default=None), None)
 

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -882,9 +882,9 @@ def validator_for(schema, default=_LATEST_VERSION):
             If unprovided, the default is to return
             the latest supported draft.
     """
-    if schema is True or schema is False:
+    if schema is True or schema is False or not u"$schema" in schema:
         return default
-    if schema.get(u"$schema", u"") not in meta_schemas:
+    if schema[u"$schema"] not in meta_schemas:
         warn(
             (
                 "This schema was not found but going to validate with latest draft. "
@@ -893,4 +893,4 @@ def validator_for(schema, default=_LATEST_VERSION):
             DeprecationWarning,
             stacklevel=2,
         )
-    return meta_schemas.get(schema.get(u"$schema", u""), default)
+    return meta_schemas.get(schema[u"$schema"], _LATEST_VERSION)

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -888,7 +888,7 @@ def validator_for(schema, default=_LATEST_VERSION):
         warn(
             (
                 "This schema was not found but going to validate with latest draft. "
-                "This will raise a SchemaError in future. "
+                "This will raise an error in future. "
             ),
             DeprecationWarning,
             stacklevel=2,

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -887,7 +887,7 @@ def validator_for(schema, default=_LATEST_VERSION):
     if schema[u"$schema"] not in meta_schemas:
         warn(
             (
-                "This schema was not found but going to validate with latest draft. "
+                "This metaschema: {metaSchema} was not found but going to validate with latest draft. ".format(metaSchema=schema[u"$schema"])
                 "This will raise an error in future. "
             ),
             DeprecationWarning,

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -881,8 +881,6 @@ def validator_for(schema, default=_LATEST_VERSION):
 
             If unprovided, the default is to return
             the latest supported draft.
-    Raises:
-        SchemaError if the schema doesn't exist
     """
     if schema is True or schema is False:
         return default

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -884,4 +884,13 @@ def validator_for(schema, default=_LATEST_VERSION):
     """
     if schema is True or schema is False:
         return default
+    if schema.get(u"$schema", u"") not in meta_schemas:
+        warn(
+            (
+                "This schema was not found but going to validate with latest draft. "
+                "This will raise a SchemaError in future. "
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
     return meta_schemas.get(schema.get(u"$schema", u""), default)

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -887,8 +887,8 @@ def validator_for(schema, default=_LATEST_VERSION):
     if schema[u"$schema"] not in meta_schemas:
         warn(
             (
-                "This metaschema was not found but going to validate with latest draft. "
-                "This will raise an error in future. "
+                "This metaschema was not found but going to validate with the "
+                "latest draft. This will raise an error in future. "
             ),
             DeprecationWarning,
             stacklevel=2,

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -887,7 +887,7 @@ def validator_for(schema, default=_LATEST_VERSION):
     if schema[u"$schema"] not in meta_schemas:
         warn(
             (
-                "This metaschema: {metaSchema} was not found but going to validate with latest draft. ".format(metaSchema=schema[u"$schema"])
+                "This metaschema was not found but going to validate with latest draft. "
                 "This will raise an error in future. "
             ),
             DeprecationWarning,


### PR DESCRIPTION
This addresses this issue #460 
Followed your lead by using the `SynchronousTestCase` . Any reason or particular features that drive using it instead of just `TestCase`?
Please let me know if you have any comments. Can't think of any other bright ideas regarding the warnings. First time using the module :) and feels like a pretty small PR so maybe I am missing something.