### PR TITLE
Add installation instructions to README: Issue #488

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,16 @@ Features
   of which properties or items failed validation.
 
 
+Installation
+------------
+
+``jsonschema`` is available on `PyPI <https://pypi.org/project/jsonschema/>`_. You can install using `pip <https://pip.pypa.io/en/stable/>`_:
+
+.. code-block:: bash
+
+    $ pip install jsonschema
+
+
 Release Notes
 -------------
 


### PR DESCRIPTION
This PR adds the `Installation` section to the README as written in #488.