### PR TITLE
Make exceptions hashable (but not comparable)

### DIFF
--- a/jsonschema/exceptions.py
+++ b/jsonschema/exceptions.py
@@ -55,16 +55,6 @@ class _Error(Exception):
         for error in context:
             error.parent = self
 
-    def __eq__(self, other):
-        if not isinstance(other, self.__class__):
-            return NotImplemented
-        return self._contents() == other._contents()
-
-    def __ne__(self, other):
-        if not isinstance(other, self.__class__):
-            return NotImplemented
-        return not self == other
-
     def __repr__(self):
         return "<%s: %r>" % (self.__class__.__name__, self.message)
 

--- a/jsonschema/tests/test_exceptions.py
+++ b/jsonschema/tests/test_exceptions.py
@@ -12,7 +12,8 @@ class TestBestMatch(TestCase):
         reversed_best = exceptions.best_match(reversed(errors))
         msg = "Didn't return a consistent best match!\nGot: {0}\n\nThen: {1}"
         self.assertEqual(
-            best, reversed_best, msg=msg.format(best, reversed_best),
+            best._contents(), reversed_best._contents(),
+            msg=msg.format(best, reversed_best),
         )
         return best
 
@@ -460,3 +461,9 @@ class TestErrorInitReprStr(TestCase):
             schema="schema",
         )
         self.assertIn(repr(instance), str(error))
+
+
+class TestHashable(TestCase):
+    def test_hashable(self):
+        set([exceptions.ValidationError("")])
+        set([exceptions.SchemaError("")])

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -73,9 +73,10 @@ class TestCreateAndExtend(SynchronousTestCase):
         schema = {u"startswith": u"hel"}
         iter_errors = self.Validator(schema).iter_errors
 
-        self.assertEqual(list(iter_errors(u"hello")), [])
+        errors = list(iter_errors(u"hello"))
+        self.assertEqual(errors, [])
 
-        error = ValidationError(
+        expected_error = ValidationError(
             u"Whoops!",
             instance=u"goodbye",
             schema=schema,
@@ -83,7 +84,10 @@ class TestCreateAndExtend(SynchronousTestCase):
             validator_value=u"hel",
             schema_path=deque([u"startswith"]),
         )
-        self.assertEqual(list(iter_errors(u"goodbye")), [error])
+
+        errors = list(iter_errors(u"goodbye"))
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]._contents(), expected_error._contents())
 
     def test_if_a_version_is_provided_it_is_registered(self):
         Validator = validators.create(


### PR DESCRIPTION
This PR addresses #477.

Currently, `ValidationError` and `SchemaError` implement `__eq__`, but don't implement `__hash__`, which makes then unhashable.  That prevents them from being used in certain scenarios, notably in a test suite that uses `pytest` [Edit: It fails under python 3.6, but not 3.7].

The easiest way to make them hashable is to simply remove the `__eq__` implementation.  I doubt many users of `jsonschema` rely on the fact that those errors are comparable.

The only problem is jsonschema's own test suite, which *does* rely on `ValidationError.__eq__()`.  But that's easy to change, as I've done in this PR.  Thoughts?