### PR TITLE
Depend on setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ install_requires =
     attrs>=17.4.0
     pyrsistent>=0.14.0
     six>=1.11.0
+    setuptools
     functools32;python_version<'3'
 
 [options.extras_require]


### PR DESCRIPTION
`pkg_resources` requires `setuptools`.  Fixes #510