### PR TITLE
Docs now build successfully out of the box on macOS CPython.

### DIFF
--- a/docs/jsonschema_role.py
+++ b/docs/jsonschema_role.py
@@ -8,6 +8,7 @@ try:
 except ImportError:
     import urllib.request as urllib
 
+import certifi
 from lxml import html
 
 
@@ -62,7 +63,7 @@ def fetch_or_load(spec_path):
             raise
 
     request = urllib.Request(VALIDATION_SPEC, headers=headers)
-    response = urllib.urlopen(request)
+    response = urllib.urlopen(request, cafile=certifi.where())
 
     if response.code == 200:
         with open(spec_path, "w+b") as spec:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+certifi
 lxml
 sphinx==1.6.7
 sphinxcontrib-spelling


### PR DESCRIPTION
Exploring possibilities of collaboration, a following up on [this conversation at #470](https://github.com/Julian/jsonschema/issues/470#issuecomment-453289512), I found out that I could not build the documentation on my laptop, running macOS with vanilla installations of CPython 3.6 and 3.7 from www.python.org.

The failure is in the `docs/jsonschema_role.py` Sphix extension, in the `fetch_or_load` function, which uses `urllib.request.urlopen` with an HTTPS URL. Unfortunately, such CPython installs fail to validate server-side TLS certificates.

The motive stems from the fact that, as stated in the installer's README, a private OpenSSL copy is included in the distribution which does not use the system certificate store for validation; instead, the suggested approach is doing a system-wide installation of the `certifi` third-party package and then creating a symlink from a file in that package to a file in the standard library (argh!).

Since I explicitly avoid installing any system-wide Python packages -- and, thus, completing the above mentioned install -- I often need to find ways to make things work. I believe many others experience similar failures due to a) actively understanding the issue and not installing system-wide things (like me), or b) not being aware of the issue and not reading the installer README where a possible solution is documented and suggested (many/most people, I'd venture).

However `urllib.request.urlopen` can be explicitly given a `cafile` argument which, again explicitly in the context of `jsonschema`, can use `certifi`'s CA list. This PR adds `certifi` as a requirement to build docs and adjusts the `urlopen` call such that is uses `certifi`'s CA list.

With this in place, the docs can be build on any platform, regardless of the (unfortunately somewhat sad) state of the underlying Python's TLS certificate validation mechanism / dependencies.

Feedback is welcome, of course.
Thanks.