### PR TITLE
Added support for 'file://' URL schema on the RefResolver

### DIFF
--- a/jsonschema/compat.py
+++ b/jsonschema/compat.py
@@ -22,7 +22,7 @@ if PY3:
     from urllib.parse import (
         unquote, urljoin, urlunsplit, SplitResult, urlsplit as _urlsplit
     )
-    from urllib.request import pathname2url, urlopen
+    from urllib.request import pathname2url, url2pathname, urlopen
     str_types = str,
     int_types = int,
     iteritems = operator.methodcaller("items")
@@ -32,7 +32,7 @@ else:
     from urlparse import (
         urljoin, urlunsplit, SplitResult, urlsplit as _urlsplit # noqa
     )
-    from urllib import pathname2url, unquote  # noqa
+    from urllib import pathname2url, url2pathname, unquote  # noqa
     import urllib2  # noqa
     def urlopen(*args, **kwargs):
         return contextlib.closing(urllib2.urlopen(*args, **kwargs))

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -25,6 +25,7 @@ from jsonschema.compat import (
     urljoin,
     urlopen,
     urlsplit,
+    url2pathname,
 )
 
 # Sigh. https://gitlab.com/pycqa/flake8/issues/280
@@ -818,6 +819,13 @@ class RefResolver(object):
 
         if scheme in self.handlers:
             result = self.handlers[scheme](uri)
+        elif scheme in [u"file", u""]:
+            # Resolve local files
+            path = uri
+            if path.startswith('file:'):
+                path = path[len('file:'):]
+            with open(url2pathname(path)) as _file:
+                result = json.load(_file)
         elif scheme in [u"http", u"https"] and requests:
             # Requests has support for detecting the correct encoding of
             # json over http


### PR DESCRIPTION
Fixes Julian/jsonschema#398

### Difference
Before this fix, RefResolver created with `base_uri` starting with `file://` could work not properly.

#### Example code to test:
```python
import os.path
import json

from jsonschema import validate, RefResolver

contact = \
{
    "name": "William Johns",
    "age": 25,
    "birthDate": { "month": "apr", "day": 15 }
}

def main():
    schema_path = "schemas/main_schema.json"
    schema = json.load(open(schema_path))
    validate(contact, schema, resolver=RefResolver(base_uri='file://' + os.path.dirname(os.path.abspath(schema_path)), referrer=schema))

if (__name__ == '__main__'):
    main()
```

#### Work tree:
```
    /
    +-- code.py
    +-- schemas /
    |   +-- dependencies /
    |   |   +-- date.json
    |   |   +-- month.json
    |   |   +-- positive_integer.json
    |   +-- main_schema.json
```

#### $ref Dependencies:
```
main_schema => date, positive_integer
date => month, positive_integer
```

### Tests
Tests passed on:
 - [x] Windows 7, Python 2.7.15
 - [x] Windows 7, Python 3.5.2
 - [x] Windows 7, Python 3.7.2

Would also test on:
 - [ ] Linux (Ubuntu 16.04), Python 2.7.
 - [ ] Linux (Ubuntu 16.04), Python 3.5.2
 - [ ] Linux (Ubuntu 16.04), Python 3.6.7
 - [ ] Linux (Ubuntu 16.04), Python 3.7.2
