### PR TITLE
Fix parsing relative references to other files

### DIFF
--- a/jsonschema/cli.py
+++ b/jsonschema/cli.py
@@ -3,6 +3,8 @@ import argparse
 import json
 import sys
 
+from six.moves import urllib, urllib_parse
+
 from jsonschema._reflect import namedAny
 from jsonschema.validators import validator_for
 
@@ -15,7 +17,14 @@ def _namedAnyWithDefault(name):
 
 def _json_file(path):
     with open(path) as file:
-        return json.load(file)
+        doc = json.load(file)
+
+        if type(doc) == dict and '$id' not in doc:
+            # Add an ID so that relative refs to other files can be resolved
+            doc['$id'] = urllib_parse.urljoin(
+                'file:', urllib.request.pathname2url(path))
+
+        return doc
 
 
 parser = argparse.ArgumentParser(


### PR DESCRIPTION
This sets the $id attribute to the absolute file URI if it is not already set,
so that a base URI is available and the existing code for resolving references
can be used.