### PR TITLE
Adding falsy value evaluation to Unset

### DIFF
--- a/jsonschema/_utils.py
+++ b/jsonschema/_utils.py
@@ -47,7 +47,6 @@ class Unset(object):
     def __repr__(self):
         return "<unset>"
 
-    
     def __nonzero__(self):
         return False
 

--- a/jsonschema/_utils.py
+++ b/jsonschema/_utils.py
@@ -47,6 +47,10 @@ class Unset(object):
     def __repr__(self):
         return "<unset>"
 
+    
+    def __nonzero__(self):
+        return False
+
 
 def load_schema(name):
     """


### PR DESCRIPTION
Causing Unset to have falsy behaviour can simplify tests and other checks.