### PR TITLE
Update meta schema files in project

### DIFF
--- a/jsonschema/schemas/draft3.json
+++ b/jsonschema/schemas/draft3.json
@@ -15,7 +15,7 @@
 
         "properties": {
             "type": "object",
-            "additionalProperties": {"type": "object", "$ref": "#"},
+			"additionalProperties" : {"$ref" : "#"},
             "default": {}
         },
 
@@ -47,7 +47,7 @@
         },
 
         "dependencies": {
-            "type": ["string", "array", "object"],
+			"type" : "object",
             "additionalProperties": {
                 "type": ["string", "array", {"$ref": "#"}],
                 "items": {
@@ -157,11 +157,6 @@
             "format": "uri"
         },
 
-        "maxDecimal": {
-            "minimum": 0,
-            "type": "number"
-        },
-
         "$schema": {
             "type": "string",
             "format": "uri"
@@ -171,6 +166,7 @@
     "dependencies": {
         "exclusiveMinimum": "minimum",
         "exclusiveMaximum": "maximum"
-    }
+	},
 
+	"default" : {}
 }

--- a/jsonschema/schemas/draft3.json
+++ b/jsonschema/schemas/draft3.json
@@ -1,199 +1,176 @@
 {
     "$schema": "http://json-schema.org/draft-03/schema#",
-    "dependencies": {
-        "exclusiveMaximum": "maximum",
-        "exclusiveMinimum": "minimum"
-    },
     "id": "http://json-schema.org/draft-03/schema#",
+    "type": "object",
+
     "properties": {
-        "$ref": {
-            "format": "uri",
-            "type": "string"
+        "type": {
+            "type": ["string", "array"],
+            "items": {
+                "type": ["string", {"$ref": "#"}]
+            },
+            "uniqueItems": true,
+            "default": "any"
         },
-        "$schema": {
-            "format": "uri",
-            "type": "string"
+
+        "properties": {
+            "type": "object",
+            "additionalProperties": {"type": "object", "$ref": "#"},
+            "default": {}
         },
-        "additionalItems": {
-            "default": {},
-            "type": [
-                {
-                    "$ref": "#"
-                },
-                "boolean"
-            ]
+
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": {"$ref": "#"},
+            "default": {}
         },
+
         "additionalProperties": {
-            "default": {},
-            "type": [
-                {
-                    "$ref": "#"
-                },
-                "boolean"
-            ]
+            "type": [{"$ref": "#"}, "boolean"],
+            "default": {}
         },
-        "default": {
-            "type": "any"
+
+        "items": {
+            "type": [{"$ref": "#"}, "array"],
+            "items": {"$ref": "#"},
+            "default": {}
         },
+
+        "additionalItems": {
+            "type": [{"$ref": "#"}, "boolean"],
+            "default": {}
+        },
+
+        "required": {
+            "type": "boolean",
+            "default": false
+        },
+
         "dependencies": {
+            "type": ["string", "array", "object"],
             "additionalProperties": {
+                "type": ["string", "array", {"$ref": "#"}],
                 "items": {
                     "type": "string"
-                },
-                "type": [
-                    "string",
-                    "array",
-                    {
-                        "$ref": "#"
-                    }
-                ]
+                }
             },
-            "default": {},
-            "type": [
-                "string",
-                "array",
-                "object"
-            ]
+            "default": {}
         },
-        "description": {
-            "type": "string"
-        },
-        "disallow": {
-            "items": {
-                "type": [
-                    "string",
-                    {
-                        "$ref": "#"
-                    }
-                ]
-            },
-            "type": [
-                "string",
-                "array"
-            ],
-            "uniqueItems": true
-        },
-        "divisibleBy": {
-            "default": 1,
-            "exclusiveMinimum": true,
-            "minimum": 0,
+
+        "minimum": {
             "type": "number"
         },
+
+        "maximum": {
+            "type": "number"
+        },
+
+        "exclusiveMinimum": {
+            "type": "boolean",
+            "default": false
+        },
+
+        "exclusiveMaximum": {
+            "type": "boolean",
+            "default": false
+        },
+
+        "minItems": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0
+        },
+
+        "maxItems": {
+            "type": "integer",
+            "minimum": 0
+        },
+
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+
+        "minLength": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0
+        },
+
+        "maxLength": {
+            "type": "integer"
+        },
+
         "enum": {
             "type": "array"
         },
-        "exclusiveMaximum": {
-            "default": false,
-            "type": "boolean"
+
+        "default": {
+            "type": "any"
         },
-        "exclusiveMinimum": {
-            "default": false,
-            "type": "boolean"
+
+        "title": {
+            "type": "string"
         },
-        "extends": {
-            "default": {},
-            "items": {
-                "$ref": "#"
-            },
-            "type": [
-                {
-                    "$ref": "#"
-                },
-                "array"
-            ]
+
+        "description": {
+            "type": "string"
         },
+
         "format": {
             "type": "string"
         },
-        "id": {
-            "format": "uri",
-            "type": "string"
+
+        "divisibleBy": {
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": true,
+            "default": 1
         },
-        "items": {
-            "default": {},
+
+        "disallow": {
+            "type": ["string", "array"],
             "items": {
-                "$ref": "#"
+                "type": ["string", {"$ref": "#"}]
             },
-            "type": [
-                {
-                    "$ref": "#"
-                },
-                "array"
-            ]
+            "uniqueItems": true
         },
+
+        "extends": {
+            "type": [{"$ref": "#"}, "array"],
+            "items": {"$ref": "#"},
+            "default": {}
+        },
+
+        "id": {
+            "type": "string",
+            "format": "uri"
+        },
+
+        "$ref": {
+            "type": "string",
+            "format": "uri"
+        },
+
         "maxDecimal": {
             "minimum": 0,
             "type": "number"
         },
-        "maxItems": {
-            "minimum": 0,
-            "type": "integer"
-        },
-        "maxLength": {
-            "type": "integer"
-        },
-        "maximum": {
-            "type": "number"
-        },
-        "minItems": {
-            "default": 0,
-            "minimum": 0,
-            "type": "integer"
-        },
-        "minLength": {
-            "default": 0,
-            "minimum": 0,
-            "type": "integer"
-        },
-        "minimum": {
-            "type": "number"
-        },
-        "pattern": {
-            "format": "regex",
-            "type": "string"
-        },
-        "patternProperties": {
-            "additionalProperties": {
-                "$ref": "#"
-            },
-            "default": {},
-            "type": "object"
-        },
-        "properties": {
-            "additionalProperties": {
-                "$ref": "#",
-                "type": "object"
-            },
-            "default": {},
-            "type": "object"
-        },
-        "required": {
-            "default": false,
-            "type": "boolean"
-        },
-        "title": {
-            "type": "string"
-        },
-        "type": {
-            "default": "any",
-            "items": {
-                "type": [
-                    "string",
-                    {
-                        "$ref": "#"
-                    }
-                ]
-            },
-            "type": [
-                "string",
-                "array"
-            ],
-            "uniqueItems": true
-        },
-        "uniqueItems": {
-            "default": false,
-            "type": "boolean"
+
+        "$schema": {
+            "type": "string",
+            "format": "uri"
         }
     },
-    "type": "object"
+
+    "dependencies": {
+        "exclusiveMinimum": "minimum",
+        "exclusiveMaximum": "maximum"
+    }
+
 }

--- a/jsonschema/schemas/draft4.json
+++ b/jsonschema/schemas/draft4.json
@@ -1,222 +1,147 @@
 {
+    "id": "http://json-schema.org/draft-04/schema#",
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "default": {},
+    "description": "Core schema meta-schema",
     "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#" }
+        },
         "positiveInteger": {
-            "minimum": 0,
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0
         },
         "positiveIntegerDefault0": {
-            "allOf": [
-                {
-                    "$ref": "#/definitions/positiveInteger"
-                },
-                {
-                    "default": 0
-                }
-            ]
-        },
-        "schemaArray": {
-            "items": {
-                "$ref": "#"
-            },
-            "minItems": 1,
-            "type": "array"
+            "allOf": [ { "$ref": "#/definitions/positiveInteger" }, { "default": 0 } ]
         },
         "simpleTypes": {
-            "enum": [
-                "array",
-                "boolean",
-                "integer",
-                "null",
-                "number",
-                "object",
-                "string"
-            ]
+            "enum": [ "array", "boolean", "integer", "null", "number", "object", "string" ]
         },
         "stringArray": {
-            "items": {
-                "type": "string"
-            },
-            "minItems": 1,
             "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1,
             "uniqueItems": true
         }
     },
-    "dependencies": {
-        "exclusiveMaximum": [
-            "maximum"
-        ],
-        "exclusiveMinimum": [
-            "minimum"
-        ]
-    },
-    "description": "Core schema meta-schema",
-    "id": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
     "properties": {
-        "$schema": {
-            "format": "uri",
-            "type": "string"
-        },
-        "additionalItems": {
-            "anyOf": [
-                {
-                    "type": "boolean"
-                },
-                {
-                    "$ref": "#"
-                }
-            ],
-            "default": {}
-        },
-        "additionalProperties": {
-            "anyOf": [
-                {
-                    "type": "boolean"
-                },
-                {
-                    "$ref": "#"
-                }
-            ],
-            "default": {}
-        },
-        "allOf": {
-            "$ref": "#/definitions/schemaArray"
-        },
-        "anyOf": {
-            "$ref": "#/definitions/schemaArray"
-        },
-        "default": {},
-        "definitions": {
-            "additionalProperties": {
-                "$ref": "#"
-            },
-            "default": {},
-            "type": "object"
-        },
-        "dependencies": {
-            "additionalProperties": {
-                "anyOf": [
-                    {
-                        "$ref": "#"
-                    },
-                    {
-                        "$ref": "#/definitions/stringArray"
-                    }
-                ]
-            },
-            "type": "object"
-        },
-        "description": {
-            "type": "string"
-        },
-        "enum": {
-            "type": "array"
-        },
-        "exclusiveMaximum": {
-            "default": false,
-            "type": "boolean"
-        },
-        "exclusiveMinimum": {
-            "default": false,
-            "type": "boolean"
-        },
-        "format": {
-            "type": "string"
-        },
         "id": {
-            "format": "uri",
             "type": "string"
         },
-        "items": {
-            "anyOf": [
-                {
-                    "$ref": "#"
-                },
-                {
-                    "$ref": "#/definitions/schemaArray"
-                }
-            ],
-            "default": {}
-        },
-        "maxItems": {
-            "$ref": "#/definitions/positiveInteger"
-        },
-        "maxLength": {
-            "$ref": "#/definitions/positiveInteger"
-        },
-        "maxProperties": {
-            "$ref": "#/definitions/positiveInteger"
-        },
-        "maximum": {
-            "type": "number"
-        },
-        "minItems": {
-            "$ref": "#/definitions/positiveIntegerDefault0"
-        },
-        "minLength": {
-            "$ref": "#/definitions/positiveIntegerDefault0"
-        },
-        "minProperties": {
-            "$ref": "#/definitions/positiveIntegerDefault0"
-        },
-        "minimum": {
-            "type": "number"
-        },
-        "multipleOf": {
-            "exclusiveMinimum": true,
-            "minimum": 0,
-            "type": "number"
-        },
-        "not": {
-            "$ref": "#"
-        },
-        "oneOf": {
-            "$ref": "#/definitions/schemaArray"
-        },
-        "pattern": {
-            "format": "regex",
+        "$schema": {
             "type": "string"
-        },
-        "patternProperties": {
-            "additionalProperties": {
-                "$ref": "#"
-            },
-            "default": {},
-            "type": "object"
-        },
-        "properties": {
-            "additionalProperties": {
-                "$ref": "#"
-            },
-            "default": {},
-            "type": "object"
-        },
-        "required": {
-            "$ref": "#/definitions/stringArray"
         },
         "title": {
             "type": "string"
         },
+        "description": {
+            "type": "string"
+        },
+        "default": {},
+        "multipleOf": {
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": true
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "boolean",
+            "default": false
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxLength": { "$ref": "#/definitions/positiveInteger" },
+        "minLength": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "additionalItems": {
+            "anyOf": [
+                { "type": "boolean" },
+                { "$ref": "#" }
+            ],
+            "default": {}
+        },
+        "items": {
+            "anyOf": [
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
+            ],
+            "default": {}
+        },
+        "maxItems": { "$ref": "#/definitions/positiveInteger" },
+        "minItems": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxProperties": { "$ref": "#/definitions/positiveInteger" },
+        "minProperties": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "required": { "$ref": "#/definitions/stringArray" },
+        "additionalProperties": {
+            "anyOf": [
+                { "type": "boolean" },
+                { "$ref": "#" }
+            ],
+            "default": {}
+        },
+        "definitions": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#" },
+                    { "$ref": "#/definitions/stringArray" }
+                ]
+            }
+        },
+        "enum": {
+            "type": "array"
+        },
         "type": {
             "anyOf": [
+                { "$ref": "#/definitions/simpleTypes" },
                 {
-                    "$ref": "#/definitions/simpleTypes"
-                },
-                {
-                    "items": {
-                        "$ref": "#/definitions/simpleTypes"
-                    },
-                    "minItems": 1,
                     "type": "array",
+                    "items": { "$ref": "#/definitions/simpleTypes" },
+                    "minItems": 1,
                     "uniqueItems": true
                 }
             ]
         },
-        "uniqueItems": {
-            "default": false,
-            "type": "boolean"
-        }
+        "format": { "type": "string" },
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" }
     },
-    "type": "object"
+    "dependencies": {
+        "exclusiveMaximum": [ "maximum" ],
+        "exclusiveMinimum": [ "minimum" ]
+    },
+    "default": {}
 }

--- a/jsonschema/schemas/draft6.json
+++ b/jsonschema/schemas/draft6.json
@@ -115,6 +115,7 @@
         "patternProperties": {
             "type": "object",
             "additionalProperties": { "$ref": "#" },
+            "propertyNames": { "format": "regex" },
             "default": {}
         },
         "dependencies": {

--- a/jsonschema/schemas/draft6.json
+++ b/jsonschema/schemas/draft6.json
@@ -115,7 +115,6 @@
         "patternProperties": {
             "type": "object",
             "additionalProperties": { "$ref": "#" },
-            "propertyNames": { "format": "regex" },
             "default": {}
         },
         "dependencies": {


### PR DESCRIPTION
Official meta schema files has been changed since they got committed to the project.
This PR is to bring them in sync with official meta schema files. This PR enables us to do easy diffs in the future.

Official:
http://json-schema.org/draft-03/schema#
http://json-schema.org/draft-04/schema#
http://json-schema.org/draft-06/schema#
http://json-schema.org/draft-07/schema#

Good news is: draft-7 and draft-6 are pretty close to official files.

Files in ./jsonschema/schema/ has been reviewed:
a) all elements are re-sorted to be in sync with element ordering of official schema files (to enable easy PR review)
b) formatting is now in sync with official schema
c) git commit history is inspected to find intended changed
d) patches of the jsonschema project are kept intact
e) rest is updated to become in sync with official meta schema files

For easyer PR review i created separate commits on each step - please review this PR commit-by-commit.

Please execute your test before merge to master to ensure that everything works as expected. You may want to check if your "fail rate" (https://github.com/ebdrup/json-schema-benchmark/blob/master/reports/jsonschema.md) has changed.
If this PR undo an intended patch (now stated in the commit history), let me know, i will re-apply it / update the PR.

BTW: i have to deal with draft-03 and draft-04 JSON instances in a project - that is the reason why i put efforts in these old meta schema files.