### PR TITLE
Get input from commandline when instance(s) not provided

### DIFF
--- a/jsonschema/cli.py
+++ b/jsonschema/cli.py
@@ -22,6 +22,10 @@ def _json_file(path):
         return json.load(file)
 
 
+def _read_from_stdin():
+    return json.loads(sys.stdin.read())
+
+
 parser = argparse.ArgumentParser(
     description="JSON Schema Validation CLI",
 )
@@ -83,8 +87,9 @@ def run(arguments, stdout=sys.stdout, stderr=sys.stderr):
     validator.check_schema(arguments["schema"])
 
     errored = False
-    for instance in arguments["instances"] or ():
+    for instance in arguments["instances"] or (_read_from_stdin(),):
         for error in validator.iter_errors(instance):
             stderr.write(error_format.format(error=error))
             errored = True
+
     return errored

--- a/jsonschema/cli.py
+++ b/jsonschema/cli.py
@@ -22,8 +22,8 @@ def _json_file(path):
         return json.load(file)
 
 
-def _read_from_stdin():
-    return json.loads(sys.stdin.read())
+def _read_from_stdin(stdin):
+    return json.loads(stdin.read())
 
 
 parser = argparse.ArgumentParser(
@@ -80,14 +80,14 @@ def main(args=sys.argv[1:]):
     sys.exit(run(arguments=parse_args(args=args)))
 
 
-def run(arguments, stdout=sys.stdout, stderr=sys.stderr):
+def run(arguments, stdout=sys.stdout, stderr=sys.stderr, stdin=sys.stdin):
     error_format = arguments["error_format"]
     validator = arguments["validator"](schema=arguments["schema"])
 
     validator.check_schema(arguments["schema"])
 
     errored = False
-    for instance in arguments["instances"] or (_read_from_stdin(),):
+    for instance in arguments["instances"] or (_read_from_stdin(stdin),):
         for error in validator.iter_errors(instance):
             stderr.write(error_format.format(error=error))
             errored = True

--- a/jsonschema/tests/test_cli.py
+++ b/jsonschema/tests/test_cli.py
@@ -1,4 +1,10 @@
-from unittest import TestCase, mock
+from unittest import TestCase
+
+try:
+    from unittest import mock
+except ImportError:
+    from mock import mock
+
 import json
 import subprocess
 import sys

--- a/jsonschema/tests/test_cli.py
+++ b/jsonschema/tests/test_cli.py
@@ -3,11 +3,6 @@ import json
 import subprocess
 import sys
 
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
-
 from jsonschema import Draft4Validator, ValidationError, cli, __version__
 from jsonschema.compat import NativeIO
 from jsonschema.exceptions import SchemaError
@@ -156,8 +151,7 @@ class TestCLI(TestCase):
         self.assertEqual(version, __version__)
 
     def test_piping(self):
-        sys.stdin = StringIO("{}")
-        stdout, stderr = NativeIO(), NativeIO()
+        stdout, stderr, stdin = NativeIO(), NativeIO(), NativeIO("{}")
         exit_code = cli.run(
             {
                 "validator": fake_validator(),
@@ -167,6 +161,7 @@ class TestCLI(TestCase):
             },
             stdout=stdout,
             stderr=stderr,
+            stdin=stdin,
         )
         self.assertFalse(stdout.getvalue())
         self.assertFalse(stderr.getvalue())

--- a/jsonschema/tests/test_cli.py
+++ b/jsonschema/tests/test_cli.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from unittest import TestCase, mock
 import json
 import subprocess
 import sys
@@ -149,3 +149,22 @@ class TestCLI(TestCase):
         )
         version = version.decode("utf-8").strip()
         self.assertEqual(version, __version__)
+
+    @mock.patch("sys.stdin")
+    def test_piping(self, mock_stdin):
+        mock_stdin.read.return_value = "{}"
+        stdout, stderr = NativeIO(), NativeIO()
+        exit_code = cli.run(
+            {
+                "validator": fake_validator(),
+                "schema": {},
+                "instances": [],
+                "error_format": "{error.message}",
+            },
+            stdout=stdout,
+            stderr=stderr,
+        )
+        mock_stdin.read.assert_called_once_with()
+        self.assertFalse(stdout.getvalue())
+        self.assertFalse(stderr.getvalue())
+        self.assertEqual(exit_code, 0)

--- a/jsonschema/tests/test_cli.py
+++ b/jsonschema/tests/test_cli.py
@@ -1,13 +1,12 @@
 from unittest import TestCase
-
-try:
-    from unittest import mock
-except ImportError:
-    from mock import mock
-
 import json
 import subprocess
 import sys
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 from jsonschema import Draft4Validator, ValidationError, cli, __version__
 from jsonschema.compat import NativeIO
@@ -156,9 +155,8 @@ class TestCLI(TestCase):
         version = version.decode("utf-8").strip()
         self.assertEqual(version, __version__)
 
-    @mock.patch("sys.stdin")
-    def test_piping(self, mock_stdin):
-        mock_stdin.read.return_value = "{}"
+    def test_piping(self):
+        sys.stdin = StringIO("{}")
         stdout, stderr = NativeIO(), NativeIO()
         exit_code = cli.run(
             {
@@ -170,7 +168,6 @@ class TestCLI(TestCase):
             stdout=stdout,
             stderr=stderr,
         )
-        mock_stdin.read.assert_called_once_with()
         self.assertFalse(stdout.getvalue())
         self.assertFalse(stderr.getvalue())
         self.assertEqual(exit_code, 0)

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ deps =
     perf: pyperf
 
     tests,tests_nongpl,coverage,codecov: -r{toxinidir}/test-requirements.txt
+    pypy: mock
 
     coverage,codecov: coverage
     codecov: codecov

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,6 @@ deps =
     perf: pyperf
 
     tests,tests_nongpl,coverage,codecov: -r{toxinidir}/test-requirements.txt
-    pypy: mock
 
     coverage,codecov: coverage
     codecov: codecov


### PR DESCRIPTION
Added for this: https://github.com/Julian/jsonschema/issues/621

Can now do something like this:
`cat test.json | jsonschema test.schema`