### PR TITLE
Remove the dependency on pyrsistent

### DIFF
--- a/jsonschema/_types.py
+++ b/jsonschema/_types.py
@@ -1,6 +1,5 @@
 import numbers
 
-from pyrsistent import pmap
 import attr
 
 from jsonschema.compat import int_types, str_types
@@ -61,7 +60,7 @@ class TypeChecker(object):
 
             The initial mapping of types to their checking functions.
     """
-    _type_checkers = attr.ib(default=pmap(), converter=pmap)
+    _type_checkers = attr.ib(default=dict(), converter=dict)
 
     def is_type(self, instance, type):
         """
@@ -131,8 +130,10 @@ class TypeChecker(object):
 
             A new `TypeChecker` instance.
         """
+        new_checkers = dict(self._type_checkers)
+        new_checkers.update(definitions)
         return attr.evolve(
-            self, type_checkers=self._type_checkers.update(definitions),
+            self, type_checkers=new_checkers,
         )
 
     def remove(self, *types):
@@ -159,7 +160,8 @@ class TypeChecker(object):
         checkers = self._type_checkers
         for each in types:
             try:
-                checkers = checkers.remove(each)
+                checkers = dict(checkers)
+                checkers.pop(each)
             except KeyError:
                 raise UndefinedTypeCheck(each)
         return attr.evolve(self, type_checkers=checkers)

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ install_requires =
     attrs>=17.4.0
     functools32;python_version<'3'
     importlib_metadata;python_version<'3.8'
-    pyrsistent>=0.14.0
     six>=1.11.0
 
 [options.extras_require]


### PR DESCRIPTION
Mimic the behavior of pyrsistent by creating shallow copies of dict instead.  Verify all tests still pass for 3.7.

Sharing this patch in case you are interested.  Because of our packaging constraints, we wanted to remove this dependency.

I will not be offended if you reject the PR.  ;-)