### PR TITLE
Compare with `is` (vs ==) in enum rule

### DIFF
--- a/jsonschema/_validators.py
+++ b/jsonschema/_validators.py
@@ -241,7 +241,7 @@ def dependencies(validator, dependencies, instance, schema):
 
 
 def enum(validator, enums, instance, schema):
-    if instance == 0 or instance == 1:
+    if instance is 0 or instance is 1:
         unbooled = unbool(instance)
         if all(unbooled != unbool(each) for each in enums):
             yield ValidationError("%r is not one of %r" % (instance, enums))


### PR DESCRIPTION
Similar to #164, this patch avoids calling overridden `__eq__()` in the modified `enum` rule after v3.0.2 (due to #575),
so that e.g. pandas (series & dataframes) don't choke on enum rules.