### PR TITLE
WIP: Remove outdated benchmarking instructions.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,11 +127,7 @@ Benchmarks
 ``jsonschema``'s benchmarks make use of `pyperf
 <https://pyperf.readthedocs.io>`_.
 
-Running them can be done via ``tox -e perf``, or by invoking the ``pyperf``
-commands externally (after ensuring that both it and ``jsonschema`` itself are
-installed)::
-
-    $ python -m pyperf jsonschema/benchmarks/test_suite.py --hist --output results.json
+Running them can be done via ``tox -e perf``.
 
 To compare to a previous run, use::
 

--- a/README.rst
+++ b/README.rst
@@ -125,15 +125,9 @@ Benchmarks
 ----------
 
 ``jsonschema``'s benchmarks make use of `pyperf
-<https://pyperf.readthedocs.io>`_.
+<https://pyperf.readthedocs.io>`_. Running them can be done via:: 
 
-Running them can be done via ``tox -e perf``.
-
-To compare to a previous run, use::
-
-    $ python -m pyperf compare_to --table reference.json results.json
-
-See the ``pyperf`` documentation for more details.
+      $ tox -e perf
 
 
 Community

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ deps =
 
     perf: pyperf
 
-    tests,tests_nongpl,coverage,codecov: -r{toxinidir}/test-requirements.txt
+    tests,tests_nongpl,coverage,codecov,perf: -r{toxinidir}/test-requirements.txt
 
     coverage,codecov: coverage
     codecov: codecov


### PR DESCRIPTION
Resolves #689 

This PR removes the instructions for manually running the pyperf benchmarks from `README.rst`. It also fixes the tox environment (`tox -e perf`) for running the benchmarks, which was missing a dependency on twisted.