### PR TITLE
add base URI change support

### DIFF
--- a/jsonschema/_validators.py
+++ b/jsonschema/_validators.py
@@ -255,8 +255,11 @@ def ref(validator, ref, instance, schema):
             for error in validator.descend(instance, resolved):
                 yield error
     else:
-        scope, resolved = validator.resolver.resolve(ref)
-        validator.resolver.push_scope(scope)
+        scope, resolved = validator.resolver.resolve(ref, validator)
+        if validator.resolver.flags == 1:
+            validator.resolver.flags = 0
+        else:
+            validator.resolver.push_scope(scope)
 
         try:
             for error in validator.descend(instance, resolved):

--- a/jsonschema/tests/test_jsonschema_test_suite.py
+++ b/jsonschema/tests/test_jsonschema_test_suite.py
@@ -171,11 +171,6 @@ TestDraft4 = DRAFT4.to_unittest_testcase(
             ),
         )(test)
         or skip(
-            message=bug(),
-            subject="refRemote",
-            case_description="base URI change - change folder in subschema",
-        )(test)
-        or skip(
             message="Upstream bug in strict_rfc3339",
             subject="date-time",
             description="case-insensitive T and Z",
@@ -243,11 +238,6 @@ TestDraft6 = DRAFT6.to_unittest_testcase(
             case_description=(
                 "Location-independent identifier with base URI change in subschema"
             ),
-        )(test)
-        or skip(
-            message=bug(),
-            subject="refRemote",
-            case_description="base URI change - change folder in subschema",
         )(test)
         or skip(
             message="Upstream bug in strict_rfc3339",
@@ -318,11 +308,6 @@ TestDraft7 = DRAFT7.to_unittest_testcase(
             case_description=(
                 "Location-independent identifier with base URI change in subschema"
             ),
-        )(test)
-        or skip(
-            message=bug(),
-            subject="refRemote",
-            case_description="base URI change - change folder in subschema",
         )(test)
         or skip(
             message="Upstream bug in strict_rfc3339",


### PR DESCRIPTION
Add the following "base URI change - change folder in subschema" scene support:
```
{
        "description": "base URI change - change folder in subschema",
        "schema": {
            "$id": "http://localhost:1234/scope_change_defs2.json",
            "type" : "object",
            "properties": {"list": {"$ref": "folder/#/$defs/bar"}},
            "$defs": {
                "baz": {
                    "$id": "folder/",
                    "$defs": {
                        "bar": {
                            "type": "array",
                            "items": {"$ref": "folderInteger.json"}
                        }
                    }
                }
            }
        },
        "tests": [
            {
                "description": "number is valid",
                "data": {"list": [1]},
                "valid": true
            },
            {
                "description": "string is invalid",
                "data": {"list": ["a"]},
                "valid": false
            }
        ]
    }
```