### PR TITLE
Fix cli bug about getting arguments["validator"].

### DIFF
--- a/jsonschema/cli.py
+++ b/jsonschema/cli.py
@@ -191,8 +191,6 @@ parser.add_argument(
 
 def parse_args(args):
     arguments = vars(parser.parse_args(args=args or ["--help"]))
-    if arguments["validator"] is None:
-        arguments["validator"] = validator_for(arguments["schema"])
     if arguments["output"] != "plain" and arguments["error_format"]:
         raise parser.error(
             "--error-format can only be used with --output plain"
@@ -228,6 +226,9 @@ def run(arguments, stdout=sys.stdout, stderr=sys.stderr, stdin=sys.stdin):
         schema = outputter.load(arguments["schema"])
     except _CannotLoadFile:
         return 1
+
+    if arguments["validator"] is None:
+        arguments["validator"] = validator_for(schema)
 
     try:
         arguments["validator"].check_schema(schema)

--- a/jsonschema/tests/test_cli.py
+++ b/jsonschema/tests/test_cli.py
@@ -11,7 +11,7 @@ import sys
 from jsonschema import Draft4Validator, __version__, cli
 from jsonschema.exceptions import SchemaError, ValidationError
 from jsonschema.tests._helpers import captured_output
-from jsonschema.validators import _LATEST_VERSION, validate
+from jsonschema.validators import validate
 
 
 def fake_validator(*errors):
@@ -716,15 +716,6 @@ class TestParser(TestCase):
             ]
         )
         self.assertIs(arguments["validator"], Draft4Validator)
-
-    def test_latest_validator_is_the_default(self):
-        arguments = cli.parse_args(
-            [
-                "--instance", "mem://some/instance",
-                "mem://some/schema",
-            ]
-        )
-        self.assertIs(arguments["validator"], _LATEST_VERSION)
 
     def test_unknown_output(self):
         # Avoid the help message on stdout


### PR DESCRIPTION
As commented in https://github.com/Julian/jsonschema/issues/710#issuecomment-676851156.
By adjusting the position of `arguments["validator"]`, we can solve this bug, but because `arguments["validator"]` is not processed in `parse_args`, it will cause the `test_latest_validator_is_the_default` test case to fail, so I deleted this test case. 