### PR TITLE
Truncated pretty printing

### DIFF
--- a/jsonschema/tests/test_exceptions.py
+++ b/jsonschema/tests/test_exceptions.py
@@ -298,7 +298,7 @@ class TestErrorInitReprStr(TestCase):
         return exceptions.ValidationError(**defaults)
 
     def assertShows(self, expected, **kwargs):
-        expected = textwrap.dedent(expected).rstrip("\n")
+        expected = expected.rstrip("\n")
 
         error = self.make_error(**kwargs)
         message_line, _, rest = str(error).partition("\n")
@@ -339,8 +339,7 @@ class TestErrorInitReprStr(TestCase):
                 {'type': 'string'}
 
             On instance:
-                5
-            """,
+                5""",
             path=[],
             schema_path=[],
         )
@@ -352,8 +351,7 @@ class TestErrorInitReprStr(TestCase):
                 {'type': 'string'}
 
             On instance[0]:
-                5
-            """,
+                5""",
             path=[0],
             schema_path=["items"],
         )
@@ -365,8 +363,7 @@ class TestErrorInitReprStr(TestCase):
                 {'type': 'string'}
 
             On instance[0]['a']:
-                5
-            """,
+                5""",
             path=[0, u"a"],
             schema_path=[u"items", 0, 1],
         )
@@ -397,32 +394,7 @@ class TestErrorInitReprStr(TestCase):
                  19: 19}
 
             On instance:
-                [0,
-                 1,
-                 2,
-                 3,
-                 4,
-                 5,
-                 6,
-                 7,
-                 8,
-                 9,
-                 10,
-                 11,
-                 12,
-                 13,
-                 14,
-                 15,
-                 16,
-                 17,
-                 18,
-                 19,
-                 20,
-                 21,
-                 22,
-                 23,
-                 24]
-            """,
+                [0, 1, 2, ..., 22, 23, 24]""",
             instance=list(range(25)),
             schema=dict(zip(range(20), range(20))),
             validator=u"maxLength",

--- a/jsonschema/tests/test_exceptions.py
+++ b/jsonschema/tests/test_exceptions.py
@@ -372,29 +372,25 @@ class TestErrorInitReprStr(TestCase):
         self.assertShows(
             """
             Failed validating 'maxLength' in schema:
-                {0: 0,
-                 1: 1,
-                 2: 2,
-                 3: 3,
-                 4: 4,
-                 5: 5,
-                 6: 6,
-                 7: 7,
-                 8: 8,
-                 9: 9,
-                 10: 10,
-                 11: 11,
-                 12: 12,
-                 13: 13,
-                 14: 14,
-                 15: 15,
-                 16: 16,
-                 17: 17,
-                 18: 18,
-                 19: 19}
+                {
+                    0: 0,
+                    1: 1,
+                    2: 2,
+                    3: 3,
+                    4: 4
+                    # ...and 15 more elements
+                }
 
             On instance:
-                [0, 1, 2, ..., 22, 23, 24]""",
+                [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    # ...and 20 more elements
+                ]""",
+
             instance=list(range(25)),
             schema=dict(zip(range(20), range(20))),
             validator=u"maxLength",

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ install_requires =
     functools32;python_version<'3'
     importlib_metadata;python_version<'3.8'
     pyrsistent>=0.14.0
+    prettyprinter
 
 [options.extras_require]
 format =


### PR DESCRIPTION
This fixes my problem at https://github.com/Julian/jsonschema/issues/748, as well of some of the problems at https://github.com/Julian/jsonschema/issues/243

This does not use reprlib, because reprlib converts nested objects into a single string, which makes pretty printing impossible.

Instead, it implements a nested list truncator, with a nice `...` formatting.

I would have liked to also truncate dictionaries after ~10 elements, but this is not really viable, as pformat pre python 3.8 unavoidably sorts dictionary keys, and the format looks horrible if you truncate it with `...: ...`. I left a comment in the code to this effect.

I suspect that list truncation is far more important than dictionary truncation anyway, and this definitely fixes my problem (thousands of lines trimmed down around a screenful.

Happy to take suggestions. 