### PR TITLE
[RFC]validators: add yaml parsing based on suffix

### DIFF
--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -1793,6 +1793,8 @@ class ReallyFakeRequests(object):
 class _ReallyFakeJSONResponse(object):
 
     _response = attr.ib()
+    text = str(_response)
 
     def json(self):
         return json.loads(self._response)
+


### PR DESCRIPTION
"JSON Schema" schemas are not only written in JSON but also in YAML, a
popular example is the Linux Kernel[0]. While it is possible to convert
any input file from YAML to JSON on the fly[1], the automatic resolving
of schema references is not possible.

To allow YAML files for the CLI tool of jsonschema, check the file
suffix and parse the referenced file as YAML if it ends on `yaml` or
`yml`. In case the Python library `pyyaml` is not installed or any other
suffix is found, parsing defaults to JSON as before.

[0]: https://github.com/torvalds/linux/tree/master/Documentation/devicetree/bindings
[1]: https://github.com/Julian/jsonschema/issues/582#issuecomment-515493348

Signed-off-by: Paul Spooren <mail@aparcar.org>