### PR TITLE
Add pre-commit hook config

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: jsonschema
+  name: jsonschema
+  description: json schema validation
+  language: python
+  pass_filenames: false
+  entry: jsonschema


### PR DESCRIPTION
Hi, I think it would be useful to add support for jsonschema as [pre-commit](https://github.com/pre-commit/pre-commit) hook. I think this would be more convenient than using local hooks or creating a mirror repo. 

With the way I set it up, the hook can be used with a config like this:

```yaml
repos:
  - repo: https://github.com/AleksaC/jsonschema
    rev: 639bc64d82
    hooks:
      - id: jsonschema
        files: |
          (?x)(
            ^valid.json$ |
            ^invalid.json$ |
            ^schema.json$
          )
        args: ["-i", "valid.json", "-i", "invalid.json", "schema.json"]

      - id: jsonschema
        files: |
          (?x)(
            ^valid2.json$ |
            ^invalid2.json$ |
            ^schema2.json$
          )
        args: ["-i", "valid2.json", "-i", "invalid2.json", "schema2.json"]
```