### PR TITLE
Sort extra properties for additionalProperties errors

### DIFF
--- a/jsonschema/_validators.py
+++ b/jsonschema/_validators.py
@@ -63,7 +63,7 @@ def additionalProperties(validator, aP, instance, schema):
             yield ValidationError(error)
         else:
             error = "Additional properties are not allowed (%s %s unexpected)"
-            yield ValidationError(error % extras_msg(extras))
+            yield ValidationError(error % extras_msg(sorted(extras)))
 
 
 def items(validator, items, instance, schema):


### PR DESCRIPTION
extras is a set which is unordered. Let's sort it so users get
consistent error messages.

Signed-off-by: Rob Herring <robh@kernel.org>