### PR TITLE
Fix fuzzer

### DIFF
--- a/jsonschema/tests/fuzz_validate.py
+++ b/jsonschema/tests/fuzz_validate.py
@@ -17,10 +17,9 @@ PRIM = strategies.one_of(
     strategies.text(),
 )
 DICT = strategies.recursive(
-    base=(
-        strategies.booleans()
-        | strategies.dictionaries(strategies.text(), PRIM),
-    ),
+    base=strategies.one_of(
+        strategies.booleans(),
+        strategies.dictionaries(strategies.text(), PRIM)),
     extend=lambda inner: strategies.dictionaries(strategies.text(), inner),
 )
 


### PR DESCRIPTION
The current fuzzer is broken with 
```
  File "hypothesis/core.py", line 919, in fuzz_one_input
AttributeError: 'HypothesisHandle' object has no attribute '_HypothesisHandle__cached_target'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "jsonschema/tests/fuzz_validate.py", line 47, in <module>
  File "jsonschema/tests/fuzz_validate.py", line 40, in main
  File "hypothesis/core.py", line 921, in fuzz_one_input
  File "hypothesis/core.py", line 1174, in _get_fuzz_target
  File "hypothesis/core.py", line 441, in process_arguments_to_given
  File "hypothesis/strategies/_internal/strategies.py", line 377, in validate
  File "hypothesis/strategies/_internal/collections.py", line 41, in do_validate
  File "hypothesis/strategies/_internal/strategies.py", line 377, in validate
  File "hypothesis/strategies/_internal/strategies.py", line 768, in do_validate
  File "hypothesis/strategies/_internal/strategies.py", line 377, in validate
  File "hypothesis/strategies/_internal/lazy.py", line 135, in do_validate
  File "hypothesis/strategies/_internal/strategies.py", line 377, in validate
  File "hypothesis/strategies/_internal/strategies.py", line 768, in do_validate
  File "hypothesis/strategies/_internal/strategies.py", line 377, in validate
  File "hypothesis/strategies/_internal/collections.py", line 41, in do_validate
  File "hypothesis/strategies/_internal/strategies.py", line 377, in validate
  File "hypothesis/strategies/_internal/recursive.py", line 100, in do_validate
  File "hypothesis/strategies/_internal/strategies.py", line 934, in check_strategy
```

This PR fixes this. 