### PR TITLE
allOf required properties

### DIFF
--- a/jsonschema/_validators.py
+++ b/jsonschema/_validators.py
@@ -331,14 +331,12 @@ def allOf(validator, allOf, instance, schema):
         if u"properties" in subschema:
             all_properties.update(subschema["properties"])
         elif u"$ref" in subschema:
-            resolve = getattr(validator.resolver, "resolve", None)
             scope, resolved = validator.resolver.resolve(subschema[u"$ref"])
             if u"properties" in resolved:
                 all_properties.update(resolved[u"properties"])
     for index, subschema in enumerate(allOf):
         if hasattr(subschema, '__iter__'):
             subschema["properties"] = all_properties
-
         for error in validator.descend(instance, subschema, schema_path=index):
             yield error
 

--- a/jsonschema/_validators.py
+++ b/jsonschema/_validators.py
@@ -324,7 +324,17 @@ def maxProperties(validator, mP, instance, schema):
 
 
 def allOf(validator, allOf, instance, schema):
+    all_properties = {}
     for index, subschema in enumerate(allOf):
+        if u"properties" in subschema:
+            all_properties.update(subschema["properties"])
+        elif u"$ref" in subschema:
+            resolve = getattr(validator.resolver, "resolve", None)
+            scope, resolved = validator.resolver.resolve(subschema[u"$ref"])
+            if u"properties" in resolved:
+                all_properties.update(resolved[u"properties"])           
+    for index, subschema in enumerate(allOf):
+        subschema["properties"] = all_properties
         for error in validator.descend(instance, subschema, schema_path=index):
             yield error
 

--- a/jsonschema/_validators.py
+++ b/jsonschema/_validators.py
@@ -326,6 +326,8 @@ def maxProperties(validator, mP, instance, schema):
 def allOf(validator, allOf, instance, schema):
     all_properties = {}
     for index, subschema in enumerate(allOf):
+        if not hasattr(subschema, '__iter__'):
+            continue
         if u"properties" in subschema:
             all_properties.update(subschema["properties"])
         elif u"$ref" in subschema:
@@ -334,7 +336,9 @@ def allOf(validator, allOf, instance, schema):
             if u"properties" in resolved:
                 all_properties.update(resolved[u"properties"])
     for index, subschema in enumerate(allOf):
-        subschema["properties"] = all_properties
+        if hasattr(subschema, '__iter__'):
+            subschema["properties"] = all_properties
+
         for error in validator.descend(instance, subschema, schema_path=index):
             yield error
 

--- a/jsonschema/_validators.py
+++ b/jsonschema/_validators.py
@@ -332,7 +332,7 @@ def allOf(validator, allOf, instance, schema):
             resolve = getattr(validator.resolver, "resolve", None)
             scope, resolved = validator.resolver.resolve(subschema[u"$ref"])
             if u"properties" in resolved:
-                all_properties.update(resolved[u"properties"])           
+                all_properties.update(resolved[u"properties"])
     for index, subschema in enumerate(allOf):
         subschema["properties"] = all_properties
         for error in validator.descend(instance, subschema, schema_path=index):


### PR DESCRIPTION
Added support to specify required properties against inherited properties via allOf. See below.

components:
  schemas:
    Thing:
      type: object
      properties:
        name:
          type: string
        color:
          type: string
	age:
          type: int  
paths:
  /things:
      requestBody:
        description: Thing object
        content:
          application/json:
            schema:
		allOf:
		- $ref: '#/components/schemas/Thing'
		- type: object
	          required: 
	            - name
	            - color
	          properties:
		      species:
		         type: string  
        required: true