### PR TITLE
Fixes unique and equal checks

### DIFF
--- a/jsonschema/_utils.py
+++ b/jsonschema/_utils.py
@@ -158,10 +158,46 @@ def ensure_list(thing):
     return thing
 
 
+def dict_equal(one, two):
+    """
+    Check if two dicts are the same using `equal`
+    """
+    if len(one.keys()) != len(two.keys()):
+        return False
+
+    for key in one:
+        if key not in two:
+            return False
+        if not equal(one[key], two[key]):
+            return False
+
+    return True
+
+
+def list_equal(one, two):
+    """
+    Check if two lists are the same using `equal`
+    """
+    if len(one) != len(two):
+        return False
+
+    for i in range(0, len(one)):
+        if not equal(one[i], two[i]):
+            return False
+
+    return True
+
+
 def equal(one, two):
     """
     Check if two things are equal, but evade booleans and ints being equal.
     """
+    if isinstance(one, list) and isinstance(two, list):
+        return list_equal(one, two)
+
+    if isinstance(one, dict) and isinstance(two, dict):
+        return dict_equal(one, two)
+
     return unbool(one) == unbool(two)
 
 
@@ -192,14 +228,22 @@ def uniq(container):
         try:
             sort = sorted(unbool(i) for i in container)
             sliced = itertools.islice(sort, 1, None)
+
             for i, j in zip(sort, sliced):
+                if isinstance(i, list) and isinstance(j, list):
+                    return not list_equal(i, j)
                 if i == j:
                     return False
+
         except (NotImplementedError, TypeError):
             seen = []
             for e in container:
                 e = unbool(e)
-                if e in seen:
-                    return False
+
+                for i in seen:
+                    if isinstance(i, dict) and isinstance(e, dict):
+                        if dict_equal(i, e):
+                            return False
+
                 seen.append(e)
     return True

--- a/jsonschema/_utils.py
+++ b/jsonschema/_utils.py
@@ -217,33 +217,27 @@ def uniq(container):
     """
     Check if all of a container's elements are unique.
 
-    Successively tries first to rely that the elements are hashable, then
-    falls back on them being sortable, and finally falls back on brute
-    force.
+    Successively tries first to rely that the elements are being sortable
+    and finally falls back on brute force.
     """
-
     try:
-        return len(set(unbool(i) for i in container)) == len(container)
-    except TypeError:
-        try:
-            sort = sorted(unbool(i) for i in container)
-            sliced = itertools.islice(sort, 1, None)
+        sort = sorted(unbool(i) for i in container)
+        sliced = itertools.islice(sort, 1, None)
 
-            for i, j in zip(sort, sliced):
-                if isinstance(i, list) and isinstance(j, list):
-                    return not list_equal(i, j)
-                if i == j:
+        for i, j in zip(sort, sliced):
+            return not list_equal(list(i), list(j))
+
+    except (NotImplementedError, TypeError):
+        seen = []
+        for e in container:
+            e = unbool(e)
+
+            for i in seen:
+                if isinstance(i, dict) and isinstance(e, dict):
+                    if dict_equal(i, e):
+                        return False
+                elif i == e:
                     return False
 
-        except (NotImplementedError, TypeError):
-            seen = []
-            for e in container:
-                e = unbool(e)
-
-                for i in seen:
-                    if isinstance(i, dict) and isinstance(e, dict):
-                        if dict_equal(i, e):
-                            return False
-
-                seen.append(e)
+            seen.append(e)
     return True

--- a/jsonschema/_utils.py
+++ b/jsonschema/_utils.py
@@ -1,5 +1,6 @@
 from collections.abc import MutableMapping
 from urllib.parse import urlsplit
+import collections
 import itertools
 import json
 import pkgutil
@@ -188,14 +189,32 @@ def list_equal(one, two):
     return True
 
 
+def is_sequence(instance):
+    """
+    Checks if an instance is a sequence but not a string
+    """
+    return isinstance(
+        instance, collections.Sequence
+    ) and not isinstance(
+        instance, str
+    )
+
+
+def is_mapping(instance):
+    """
+    Checks if an instance is a mapping
+    """
+    return isinstance(instance, collections.Mapping)
+
+
 def equal(one, two):
     """
     Check if two things are equal, but evade booleans and ints being equal.
     """
-    if isinstance(one, list) and isinstance(two, list):
+    if is_sequence(one) and is_sequence(two):
         return list_equal(one, two)
 
-    if isinstance(one, dict) and isinstance(two, dict):
+    if is_mapping(one) and is_mapping(two):
         return dict_equal(one, two)
 
     return unbool(one) == unbool(two)
@@ -225,7 +244,7 @@ def uniq(container):
         sliced = itertools.islice(sort, 1, None)
 
         for i, j in zip(sort, sliced):
-            return not list_equal(list(i), list(j))
+            return not list_equal(i, j)
 
     except (NotImplementedError, TypeError):
         seen = []
@@ -233,10 +252,7 @@ def uniq(container):
             e = unbool(e)
 
             for i in seen:
-                if isinstance(i, dict) and isinstance(e, dict):
-                    if dict_equal(i, e):
-                        return False
-                elif i == e:
+                if equal(i, e):
                     return False
 
             seen.append(e)

--- a/jsonschema/tests/test_jsonschema_test_suite.py
+++ b/jsonschema/tests/test_jsonschema_test_suite.py
@@ -145,36 +145,6 @@ TestDraft3 = DRAFT3.to_unittest_testcase(
                 "$ref prevents a sibling $id from changing the base uri"
             ),
         )(test)
-        or skip(
-            message=bug(686),
-            subject="uniqueItems",
-            description="[0] and [false] are unique",
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="uniqueItems",
-            description="[1] and [true] are unique",
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="uniqueItems",
-            description="nested [0] and [false] are unique",
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="uniqueItems",
-            description="nested [1] and [true] are unique",
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="uniqueItems",
-            description='{"a": false} and {"a": 0} are unique',
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="uniqueItems",
-            description='{"a": true} and {"a": 1} are unique',
-        )(test)
     ),
 )
 
@@ -239,36 +209,6 @@ TestDraft4 = DRAFT4.to_unittest_testcase(
             message=bug(),
             subject="refRemote",
             case_description="base URI change - change folder in subschema",
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="uniqueItems",
-            description="[0] and [false] are unique",
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="uniqueItems",
-            description="[1] and [true] are unique",
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="uniqueItems",
-            description="nested [0] and [false] are unique",
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="uniqueItems",
-            description="nested [1] and [true] are unique",
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="uniqueItems",
-            description='{"a": false} and {"a": 0} are unique',
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="uniqueItems",
-            description='{"a": true} and {"a": 1} are unique',
         )(test)
     ),
 )
@@ -350,56 +290,6 @@ TestDraft6 = DRAFT6.to_unittest_testcase(
             message=bug(),
             subject="refRemote",
             case_description="base URI change - change folder in subschema",
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="uniqueItems",
-            description="[0] and [false] are unique",
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="uniqueItems",
-            description="[1] and [true] are unique",
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="uniqueItems",
-            description="nested [0] and [false] are unique",
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="uniqueItems",
-            description="nested [1] and [true] are unique",
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="uniqueItems",
-            description='{"a": false} and {"a": 0} are unique',
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="uniqueItems",
-            description='{"a": true} and {"a": 1} are unique',
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="const",
-            case_description="const with [false] does not match [0]",
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="const",
-            case_description="const with [true] does not match [1]",
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="const",
-            case_description='const with {"a": false} does not match {"a": 0}',
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="const",
-            case_description='const with {"a": true} does not match {"a": 1}',
         )(test)
     ),
 )
@@ -505,56 +395,6 @@ TestDraft7 = DRAFT7.to_unittest_testcase(
             case_description=(
                 "validation of binary-encoded media type documents"
             ),
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="uniqueItems",
-            description="[0] and [false] are unique",
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="uniqueItems",
-            description="[1] and [true] are unique",
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="uniqueItems",
-            description="nested [0] and [false] are unique",
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="uniqueItems",
-            description="nested [1] and [true] are unique",
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="uniqueItems",
-            description='{"a": false} and {"a": 0} are unique',
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="uniqueItems",
-            description='{"a": true} and {"a": 1} are unique',
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="const",
-            case_description="const with [false] does not match [0]",
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="const",
-            case_description="const with [true] does not match [1]",
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="const",
-            case_description='const with {"a": false} does not match {"a": 0}',
-        )(test)
-        or skip(
-            message=bug(686),
-            subject="const",
-            case_description='const with {"a": true} does not match {"a": 1}',
         )(test)
     ),
 )

--- a/jsonschema/tests/test_utils.py
+++ b/jsonschema/tests/test_utils.py
@@ -1,0 +1,135 @@
+from unittest import TestCase
+
+from jsonschema._utils import dict_equal, list_equal
+
+
+class TestDictEqual(TestCase):
+
+    def test_equal_dictionaries(self):
+        dict_1 = {"a": "b", "c": "d"}
+        dict_2 = {"c": "d", "a": "b"}
+        self.assertTrue(dict_equal(dict_1, dict_2))
+
+    def test_missing_key(self):
+        dict_1 = {"a": "b", "c": "d"}
+        dict_2 = {"c": "d", "x": "b"}
+        self.assertFalse(dict_equal(dict_1, dict_2))
+
+    def test_additional_key(self):
+        dict_1 = {"a": "b", "c": "d"}
+        dict_2 = {"c": "d", "a": "b", "x": "x"}
+        self.assertFalse(dict_equal(dict_1, dict_2))
+
+    def test_missing_value(self):
+        dict_1 = {"a": "b", "c": "d"}
+        dict_2 = {"c": "d", "a": "x"}
+        self.assertFalse(dict_equal(dict_1, dict_2))
+
+    def test_empty_dictionaries(self):
+        dict_1 = {}
+        dict_2 = {}
+        self.assertTrue(dict_equal(dict_1, dict_2))
+
+    def test_one_none(self):
+        dict_1 = None
+        dict_2 = {"a": "b", "c": "d"}
+        with self.assertRaises(AttributeError):
+            self.assertFalse(dict_equal(dict_1, dict_2))
+        with self.assertRaises(AttributeError):
+            self.assertFalse(dict_equal(dict_1, dict_2))
+
+    def test_both_none(self):
+        with self.assertRaises(AttributeError):
+            self.assertFalse(dict_equal(None, None))
+
+    def test_same_item(self):
+        dict_1 = {"a": "b", "c": "d"}
+        self.assertTrue(dict_equal(dict_1, dict_1))
+
+    def test_nested_dict_equal(self):
+        dict_1 = {"a": {"a": "b", "c": "d"}, "c": "d"}
+        dict_2 = {"c": "d", "a": {"a": "b", "c": "d"}}
+        self.assertTrue(dict_equal(dict_1, dict_2))
+
+    def test_nested_dict_unequal(self):
+        dict_1 = {"a": {"a": "b", "c": "d"}, "c": "d"}
+        dict_2 = {"c": "d", "a": {"a": "b", "c": "x"}}
+        self.assertFalse(dict_equal(dict_1, dict_2))
+
+    def test_nested_list_equal(self):
+        dict_1 = {"a": ["a", "b", "c", "d"], "c": "d"}
+        dict_2 = {"c": "d", "a": ["a", "b", "c", "d"]}
+        self.assertTrue(dict_equal(dict_1, dict_2))
+
+    def test_nested_list_unequal(self):
+        dict_1 = {"a": ["a", "b", "c", "d"], "c": "d"}
+        dict_2 = {"c": "d", "a": ["b", "c", "d", "a"]}
+        self.assertFalse(dict_equal(dict_1, dict_2))
+
+
+class TestListEqual(TestCase):
+
+    def test_equal_lists(self):
+        list_1 = ["a", "b", "c"]
+        list_2 = ["a", "b", "c"]
+        self.assertTrue(list_equal(list_1, list_2))
+
+    def test_unsorted_lists(self):
+        list_1 = ["a", "b", "c"]
+        list_2 = ["b", "b", "a"]
+        self.assertFalse(list_equal(list_1, list_2))
+
+    def test_first_list_larger(self):
+        list_1 = ["a", "b", "c"]
+        list_2 = ["a", "b"]
+        self.assertFalse(list_equal(list_1, list_2))
+
+    def test_second_list_larger(self):
+        list_1 = ["a", "b"]
+        list_2 = ["a", "b", "c"]
+        self.assertFalse(list_equal(list_1, list_2))
+
+    def test_list_with_none_unequal(self):
+        list_1 = ["a", "b", None]
+        list_2 = ["a", "b", "c"]
+        self.assertFalse(list_equal(list_1, list_2))
+
+        list_1 = ["a", "b", None]
+        list_2 = [None, "b", "c"]
+        self.assertFalse(list_equal(list_1, list_2))
+
+    def test_list_with_none_equal(self):
+        list_1 = ["a", None, "c"]
+        list_2 = ["a", None, "c"]
+        self.assertTrue(list_equal(list_1, list_2))
+
+    def test_empty_list(self):
+        list_1 = []
+        list_2 = []
+        self.assertTrue(list_equal(list_1, list_2))
+
+    def test_one_none(self):
+        list_1 = None
+        list_2 = []
+        with self.assertRaises(TypeError):
+            self.assertTrue(list_equal(list_1, list_2))
+
+    def test_both_none(self):
+        list_1 = None
+        list_2 = None
+        with self.assertRaises(TypeError):
+            self.assertTrue(list_equal(list_1, list_2))
+
+    def test_same_list(self):
+        list_1 = ["a", "b", "c"]
+        self.assertTrue(list_equal(list_1, list_1))
+
+    def test_equal_nested_lists(self):
+        list_1 = ["a", ["b", "c"], "d"]
+        list_2 = ["a", ["b", "c"], "d"]
+        self.assertTrue(list_equal(list_1, list_2))
+
+    def test_unequal_nested_lists(self):
+        list_1 = ["a", ["b", "c"], "d"]
+        list_2 = ["a", [], "c"]
+        self.assertFalse(list_equal(list_1, list_2))

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -1,4 +1,4 @@
-from collections import deque
+from collections import deque, namedtuple
 from contextlib import contextmanager
 from decimal import Decimal
 from io import BytesIO
@@ -1087,6 +1087,42 @@ class ValidatorTestMixin(MetaSchemaTestsMixin, object):
         with self.assertRaises(exceptions.ValidationError) as e:
             TupleValidator({"uniqueItems": True}).validate((1, 1))
         self.assertIn("(1, 1) has non-unique elements", str(e.exception))
+
+    def test_check_redefined_sequence(self):
+        """
+        Allow array to validate against another defined sequence type
+        """
+        schema = {
+            "type": "array",
+            "uniqueItems": True
+        }
+
+        MyMapping = namedtuple('MyMapping', 'a, b')
+
+        Validator = validators.extend(
+            self.Validator,
+            type_checker=self.Validator.TYPE_CHECKER.redefine(
+                "array",
+                lambda checker, thing: isinstance(thing, (list, deque)),
+            )
+        )
+
+        validator = Validator(schema)
+        validator.validate(deque(['a', None, '1', '', True]))
+        with self.assertRaises(exceptions.ValidationError):
+            validator.validate(deque(['a', 'b', 'a']))
+
+        validator.validate(deque([[False], [0]]))
+        with self.assertRaises(exceptions.ValidationError):
+            validator.validate(deque([[False], [False]]))
+
+        validator.validate([deque([False]), deque([0])])
+        with self.assertRaises(exceptions.ValidationError):
+            validator.validate([deque([False]), deque([False])])
+
+        validator.validate([MyMapping('a', 0), MyMapping('a', False)])
+        with self.assertRaises(exceptions.ValidationError):
+            validator.validate([MyMapping('a', False), MyMapping('a', False)])
 
 
 class AntiDraft6LeakMixin(object):


### PR DESCRIPTION
Extends the equal check for dictionaries and lists.

This solves #686, but it's also usefull for newer spec implementations such as draft 2020-12