### PR TITLE
Remove shebangs from nonexecutable scripts

### DIFF
--- a/jsonschema/benchmarks/issue232.py
+++ b/jsonschema/benchmarks/issue232.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 A performance benchmark using the example from issue #232.
 

--- a/jsonschema/benchmarks/json_schema_test_suite.py
+++ b/jsonschema/benchmarks/json_schema_test_suite.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 A performance benchmark using the official test suite.
 


### PR DESCRIPTION
When packaging jsonschema and poetry-core (which bundles it) in Fedora, we have
realised that there are nonexecutable files with a shebang line.

It seems that the primary purpose of these files is to be imported from Python code
and hence the shebangs appear to be unnecessary.

Shebangs are hard to handle when doing downstream packaging, because it makes
sense for upstream to use `#!/usr/bin/env` python while in the RPM package,
we need to avoid that and use a more specific interpreter. Since the
shebangs were unused, I propose to remove them to avoid problems.