### PR TITLE
Don't build universal wheels for Python 3-only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,8 @@ _cache
 _static
 _templates
 
+*.egg-info/
+build
+dist
+
 TODO

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,9 +56,6 @@ console_scripts =
 [options.package_data]
 jsonschema = schemas/*.json, schemas/*/*.json
 
-[bdist_wheel]
-universal = 1
-
 [flake8]
 inline-quotes = "
 exclude =


### PR DESCRIPTION
Universal wheels are for when you need to support both Python 2 and 3:

https://packaging.python.org/guides/distributing-packages-using-setuptools/#wheels

Before:

* `jsonschema-0.1.dev1+gdbda4f7-py2.py3-none-any.whl`

After:

* `jsonschema-0.1.dev2+g97057ed-py3-none-any.whl`

---

Also ignore some build dirs generated by running `python -m build` locally.
