### PR TITLE
validators: Fix dependentSchemas when instance is not an object

### DIFF
--- a/jsonschema/_validators.py
+++ b/jsonschema/_validators.py
@@ -265,6 +265,9 @@ def dependentRequired(validator, dependentRequired, instance, schema):
 
 
 def dependentSchemas(validator, dependentSchemas, instance, schema):
+    if not validator.is_type(instance, "object"):
+        return
+
     for property, dependency in dependentSchemas.items():
         if property not in instance:
             continue


### PR DESCRIPTION
Just like 'dependentRequired' and 'dependencies', 'dependentSchemas'
needs to handle instance not being an object.

Signed-off-by: Rob Herring <robh@kernel.org>