### PR TITLE
Add version constraint to importlib_resources

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ python_requires = >=3.7
 install_requires =
     attrs>=17.4.0
     importlib_metadata;python_version<'3.8'
-    importlib_resources;python_version<'3.9'
+    importlib_resources>=1.4.0;python_version<'3.9'
     pyrsistent>=0.14.0,!=0.17.0,!=0.17.1,!=0.17.2
 
 [options.extras_require]


### PR DESCRIPTION
Based on this recent [change in the docs](https://github.com/python/importlib_resources/commit/ed3b2d30e01121b27a6e0d0a8a478a483e437736) I opted to require `importlib_resources>=1.4.0`, but tests also passed in jsonschema when using importlib_resources v1.1.0.

Let me know if you want to use `importlib_resources>=1.1.0` instead.

For reference: https://importlib-resources.readthedocs.io/en/latest/history.html.

Fixes https://github.com/Julian/jsonschema/issues/876.