### PR TITLE
More lenient float multipleOf validation

### DIFF
--- a/jsonschema/_validators.py
+++ b/jsonschema/_validators.py
@@ -186,6 +186,16 @@ def multipleOf(validator, dB, instance, schema):
         quotient = instance / dB
         try:
             failed = int(quotient) != quotient
+            if failed and dB != int(dB):
+                # Checking if floats are integer multiples of non integer
+                # floats is asking for floating point errors. Use a more
+                # lenient validation that probably conforms to the users
+                # expectations where 101 * 0.1 == 10.1 would be true.
+                # This also conforms to behaviour in javascript jsonschema
+                # checkers
+                remainder = instance % dB
+                tolerance = float_info.epsilon * instance
+                failed = remainder > tolerance and dB - remainder > tolerance
         except OverflowError:
             # When `instance` is large and `dB` is less than one,
             # quotient can overflow to infinity; and then casting to int


### PR DESCRIPTION
Many user have ran into floating point precision errors when validation multipleOf. E.g. #818, #810, #687, #185, #320, #247. Technically it can be argued that it is silly to check if any number is an integer multiple of e.g. 0.1. Ask silly questions, get silly answers. This approach is a bit unhelpful though.

Looking at other implementations in javascript and python, other libraries struggle with [this](https://github.com/ajv-validator/ajv/issues/652) [too](https://github.com/ajv-validator/ajv/issues/1005)

Checking if 10.1 is a multiple of 0.1 yields mixed results:

```
>>> import fastjsonschema
>>> fastjsonschema.validate({"multipleOf": 0.1}, 10.1)
10.1

>>> import jsonschema_rs
>>> jsonschema_rs.JSONSchema.from_str('{"multipleOf": 0.1}').is_valid(10.1)
False
>>> jsonschema_rs.JSONSchema({"multipleOf": 0.1}).is_valid(10.1)

```
https://jsonschema.dev/ fails validation
https://www.jsonschemavalidator.net/ accepts it

And [react-jsonschema-form](https://rjsf-team.github.io/react-jsonschema-form/#eyJmb3JtRGF0YSI6MTAuMSwic2NoZW1hIjp7InR5cGUiOiJudW1iZXIiLCJtdWx0aXBsZU9mIjowLjF9LCJ1aVNjaGVtYSI6eyJmaXJzdE5hbWUiOnsidWk6YXV0b2ZvY3VzIjp0cnVlLCJ1aTplbXB0eVZhbHVlIjoiIiwidWk6YXV0b2NvbXBsZXRlIjoiZmFtaWx5LW5hbWUifSwibGFzdE5hbWUiOnsidWk6ZW1wdHlWYWx1ZSI6IiIsInVpOmF1dG9jb21wbGV0ZSI6ImdpdmVuLW5hbWUifSwiYWdlIjp7InVpOndpZGdldCI6InVwZG93biIsInVpOnRpdGxlIjoiQWdlIG9mIHBlcnNvbiIsInVpOmRlc2NyaXB0aW9uIjoiKGVhcnRoaWFuIHllYXIpIn0sImJpbyI6eyJ1aTp3aWRnZXQiOiJ0ZXh0YXJlYSJ9LCJwYXNzd29yZCI6eyJ1aTp3aWRnZXQiOiJwYXNzd29yZCIsInVpOmhlbHAiOiJIaW50OiBNYWtlIGl0IHN0cm9uZyEifSwiZGF0ZSI6eyJ1aTp3aWRnZXQiOiJhbHQtZGF0ZXRpbWUifSwidGVsZXBob25lIjp7InVpOm9wdGlvbnMiOnsiaW5wdXRUeXBlIjoidGVsIn19fSwidGhlbWUiOiJkZWZhdWx0IiwibGl2ZVNldHRpbmdzIjp7InZhbGlkYXRlIjp0cnVlLCJkaXNhYmxlIjpmYWxzZSwicmVhZG9ubHkiOmZhbHNlLCJvbWl0RXh0cmFEYXRhIjpmYWxzZSwibGl2ZU9taXQiOmZhbHNlfX0=) accepts it.

So there is no real consensus amongst the libraries. Still I find the number of issues a strong indication that the current behaviour of this library is unexpected. This PR's modifies the multipleOf behaviour to allow for float tolerance (epsilon) to be taken into account. 

