### PR TITLE
Setup mypy in `tox -e typing` and get it to pass

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,3 +3,7 @@
 branch = True
 source = jsonschema
 omit = */jsonschema/_reflect.py,*/jsonschema/__main__.py,*/jsonschema/benchmarks/*,*/jsonschema/tests/fuzz_validate.py
+
+[report]
+exclude_lines =
+    if TYPE_CHECKING:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,8 @@ jobs:
             toxenv: secrets
           - name: 3.9
             toxenv: style
+          - name: 3.9
+            toxenv: typing
         exclude:
           - os: windows-latest
             python-version:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.12
     # via sphinx
-attrs==21.2.0
+attrs==21.4.0
     # via jsonschema
 babel==2.9.1
     # via sphinx
@@ -14,11 +14,11 @@ beautifulsoup4==4.10.0
     # via furo
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.9
+charset-normalizer==2.0.10
     # via requests
 docutils==0.17.1
     # via sphinx
-furo==2021.11.23
+furo==2022.1.2
     # via -r docs/requirements.in
 idna==3.3
     # via requests
@@ -28,7 +28,7 @@ jinja2==3.0.3
     # via sphinx
 file:.#egg=jsonschema
     # via -r docs/requirements.in
-lxml==4.6.5
+lxml==4.7.1
     # via -r docs/requirements.in
 markupsafe==2.0.1
     # via jinja2
@@ -36,7 +36,7 @@ packaging==21.3
     # via sphinx
 pyenchant==3.2.2
     # via sphinxcontrib-spelling
-pygments==2.10.0
+pygments==2.11.2
     # via
     #   furo
     #   sphinx
@@ -46,13 +46,13 @@ pyrsistent==0.18.0
     # via jsonschema
 pytz==2021.3
     # via babel
-requests==2.26.0
+requests==2.27.1
     # via sphinx
 snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.3.1
     # via beautifulsoup4
-sphinx==4.3.1
+sphinx==4.3.2
     # via
     #   -r docs/requirements.in
     #   furo
@@ -69,7 +69,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sphinxcontrib-spelling==7.3.0
+sphinxcontrib-spelling==7.3.2
     # via -r docs/requirements.in
 urllib3==1.26.7
     # via requests

--- a/jsonschema/_format.py
+++ b/jsonschema/_format.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from contextlib import suppress
 from uuid import UUID
 import datetime
@@ -34,9 +36,9 @@ class FormatChecker(object):
             limit which formats will be used during validation.
     """
 
-    checkers: typing.Dict[
+    checkers: dict[
         str,
-        typing.Tuple[_FormatCheckerFunc, _CheckerRaises],
+        tuple[_FormatCheckerFunc, _CheckerRaises],
     ] = {}
 
     def __init__(self, formats=None):

--- a/jsonschema/_format.py
+++ b/jsonschema/_format.py
@@ -3,8 +3,12 @@ from uuid import UUID
 import datetime
 import ipaddress
 import re
+import typing
 
 from jsonschema.exceptions import FormatError
+
+_FormatCheckerFunc = typing.Callable[[typing.Any], bool]
+_CheckerRaises = typing.Union[Exception, typing.Tuple[Exception, ...]]
 
 
 class FormatChecker(object):
@@ -30,7 +34,10 @@ class FormatChecker(object):
             limit which formats will be used during validation.
     """
 
-    checkers = {}
+    checkers: typing.Dict[
+        str,
+        typing.Tuple[_FormatCheckerFunc, _CheckerRaises],
+    ] = {}
 
     def __init__(self, formats=None):
         if formats is None:

--- a/jsonschema/_format.py
+++ b/jsonschema/_format.py
@@ -9,9 +9,6 @@ import typing
 
 from jsonschema.exceptions import FormatError
 
-_FormatCheckerFunc = typing.Callable[[typing.Any], bool]
-_CheckerRaises = typing.Union[Exception, typing.Tuple[Exception, ...]]
-
 
 class FormatChecker(object):
     """
@@ -38,7 +35,10 @@ class FormatChecker(object):
 
     checkers: dict[
         str,
-        tuple[_FormatCheckerFunc, _CheckerRaises],
+        tuple[
+            typing.Callable[[typing.Any], bool],
+            Exception | tuple[Exception, ...],
+        ],
     ] = {}
 
     def __init__(self, formats=None):

--- a/jsonschema/_types.py
+++ b/jsonschema/_types.py
@@ -1,9 +1,24 @@
 import numbers
+import typing
 
 from pyrsistent import pmap
 import attr
 
 from jsonschema.exceptions import UndefinedTypeCheck
+
+# internal type declarations for annotations
+_TypeCheckerFunc = typing.Callable[["TypeChecker", typing.Any], bool]
+_TypeCheckerMapping = typing.Mapping[str, _TypeCheckerFunc]
+
+
+# unfortunately, the type of pmap is generic, and if used as the attr.ib
+# converter, the generic type is presented to mypy, which then fails to match
+# the concrete type of a type checker mapping
+# this "do nothing" wrapper presents the correct information to mypy
+def _typed_pmap_converter(
+    init_val: _TypeCheckerMapping,
+) -> _TypeCheckerMapping:
+    return typing.cast(_TypeCheckerMapping, pmap(init_val))
 
 
 def is_array(checker, instance):
@@ -60,7 +75,10 @@ class TypeChecker(object):
 
             The initial mapping of types to their checking functions.
     """
-    _type_checkers = attr.ib(default=pmap(), converter=pmap)
+
+    _type_checkers: _TypeCheckerMapping = attr.ib(
+        default=pmap(), converter=_typed_pmap_converter,
+    )
 
     def is_type(self, instance, type):
         """

--- a/jsonschema/_types.py
+++ b/jsonschema/_types.py
@@ -8,19 +8,24 @@ import attr
 
 from jsonschema.exceptions import UndefinedTypeCheck
 
-# internal type declarations for annotations
-_TypeCheckerFunc = typing.Callable[["TypeChecker", typing.Any], bool]
-_TypeCheckerMapping = typing.Mapping[str, _TypeCheckerFunc]
-
 
 # unfortunately, the type of pmap is generic, and if used as the attr.ib
 # converter, the generic type is presented to mypy, which then fails to match
 # the concrete type of a type checker mapping
 # this "do nothing" wrapper presents the correct information to mypy
 def _typed_pmap_converter(
-    init_val: _TypeCheckerMapping,
-) -> _TypeCheckerMapping:
-    return typing.cast(_TypeCheckerMapping, pmap(init_val))
+    init_val: typing.Mapping[
+        str,
+        typing.Callable[["TypeChecker", typing.Any], bool],
+    ],
+) -> typing.Mapping[str, typing.Callable[["TypeChecker", typing.Any], bool]]:
+    return typing.cast(
+        typing.Mapping[
+            str,
+            typing.Callable[["TypeChecker", typing.Any], bool],
+        ],
+        pmap(init_val),
+    )
 
 
 def is_array(checker, instance):
@@ -78,8 +83,11 @@ class TypeChecker(object):
             The initial mapping of types to their checking functions.
     """
 
-    _type_checkers: _TypeCheckerMapping = attr.ib(
-        default=pmap(), converter=_typed_pmap_converter,
+    _type_checkers: typing.Mapping[
+        str, typing.Callable[["TypeChecker", typing.Any], bool],
+    ] = attr.ib(
+        default=pmap(),
+        converter=_typed_pmap_converter,
     )
 
     def is_type(self, instance, type):

--- a/jsonschema/_types.py
+++ b/jsonschema/_types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numbers
 import typing
 

--- a/jsonschema/_utils.py
+++ b/jsonschema/_utils.py
@@ -9,7 +9,7 @@ import sys
 if sys.version_info >= (3, 9):  # pragma: no cover
     from importlib import resources
 else:  # pragma: no cover
-    import importlib_resources as resources
+    import importlib_resources as resources  # type: ignore
 
 
 class URIDict(MutableMapping):

--- a/jsonschema/cli.py
+++ b/jsonschema/cli.py
@@ -12,7 +12,7 @@ import traceback
 try:
     from importlib import metadata
 except ImportError:
-    import importlib_metadata as metadata
+    import importlib_metadata as metadata  # type: ignore
 
 import attr
 

--- a/jsonschema/exceptions.py
+++ b/jsonschema/exceptions.py
@@ -1,18 +1,19 @@
 """
 Validation errors, and some surrounding helpers.
 """
+from __future__ import annotations
+
 from collections import defaultdict, deque
 from pprint import pformat
 from textwrap import dedent, indent
 import itertools
-import typing
 
 import attr
 
 from jsonschema import _utils
 
-WEAK_MATCHES: typing.FrozenSet[str] = frozenset(["anyOf", "oneOf"])
-STRONG_MATCHES: typing.FrozenSet[str] = frozenset()
+WEAK_MATCHES: frozenset[str] = frozenset(["anyOf", "oneOf"])
+STRONG_MATCHES: frozenset[str] = frozenset()
 
 _unset = _utils.Unset()
 

--- a/jsonschema/exceptions.py
+++ b/jsonschema/exceptions.py
@@ -5,13 +5,14 @@ from collections import defaultdict, deque
 from pprint import pformat
 from textwrap import dedent, indent
 import itertools
+import typing
 
 import attr
 
 from jsonschema import _utils
 
-WEAK_MATCHES = frozenset(["anyOf", "oneOf"])
-STRONG_MATCHES = frozenset()
+WEAK_MATCHES: typing.FrozenSet[str] = frozenset(["anyOf", "oneOf"])
+STRONG_MATCHES: typing.FrozenSet[str] = frozenset()
 
 _unset = _utils.Unset()
 

--- a/jsonschema/protocols.py
+++ b/jsonschema/protocols.py
@@ -5,7 +5,9 @@ typing.Protocol classes for jsonschema interfaces.
 # for reference material on Protocols, see
 #   https://www.python.org/dev/peps/pep-0544/
 
-from typing import Any, ClassVar, Iterator, Optional, Union
+from __future__ import annotations
+
+from typing import Any, ClassVar, Iterator
 import sys
 
 # doing these imports with `try ... except ImportError` doesn't pass mypy
@@ -73,13 +75,13 @@ class Validator(Protocol):
     TYPE_CHECKER: ClassVar[TypeChecker]
 
     #: The schema that was passed in when initializing the object.
-    schema: Union[dict, bool]
+    schema: dict | bool
 
     def __init__(
         self,
-        schema: Union[dict, bool],
-        resolver: Optional[RefResolver] = None,
-        format_checker: Optional[FormatChecker] = None,
+        schema: dict | bool,
+        resolver: RefResolver | None = None,
+        format_checker: FormatChecker | None = None,
     ) -> None:
         ...
 

--- a/jsonschema/protocols.py
+++ b/jsonschema/protocols.py
@@ -7,7 +7,7 @@ typing.Protocol classes for jsonschema interfaces.
 
 from __future__ import annotations
 
-from typing import Any, ClassVar, Iterator
+from typing import TYPE_CHECKING, Any, ClassVar, Iterator
 import sys
 
 # doing these imports with `try ... except ImportError` doesn't pass mypy
@@ -22,8 +22,13 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Protocol, runtime_checkable
 
-from jsonschema._format import FormatChecker
-from jsonschema._types import TypeChecker
+# in order for Sphinx to resolve references accurately from type annotations,
+# it needs to see names like `jsonschema.TypeChecker`
+# therefore, only import at type-checking time (to avoid circular references),
+# but use `jsonschema` for any types which will otherwise not be resolvable
+if TYPE_CHECKING:
+    import jsonschema
+
 from jsonschema.exceptions import ValidationError
 from jsonschema.validators import RefResolver
 
@@ -72,7 +77,7 @@ class Validator(Protocol):
 
     #: A `jsonschema.TypeChecker` that will be used when validating
     #: :validator:`type` properties in JSON schemas.
-    TYPE_CHECKER: ClassVar[TypeChecker]
+    TYPE_CHECKER: ClassVar[jsonschema.TypeChecker]
 
     #: The schema that was passed in when initializing the object.
     schema: dict | bool
@@ -81,7 +86,7 @@ class Validator(Protocol):
         self,
         schema: dict | bool,
         resolver: RefResolver | None = None,
-        format_checker: FormatChecker | None = None,
+        format_checker: jsonschema.FormatChecker | None = None,
     ) -> None:
         ...
 

--- a/jsonschema/protocols.py
+++ b/jsonschema/protocols.py
@@ -6,10 +6,18 @@ typing.Protocol classes for jsonschema interfaces.
 #   https://www.python.org/dev/peps/pep-0544/
 
 from typing import Any, ClassVar, Iterator, Optional, Union
+import sys
 
-try:
+# doing these imports with `try ... except ImportError` doesn't pass mypy
+# checking because mypy sees `typing._SpecialForm` and
+# `typing_extensions._SpecialForm` as incompatible
+#
+# see:
+# https://mypy.readthedocs.io/en/stable/runtime_troubles.html#using-new-additions-to-the-typing-module
+# https://github.com/python/mypy/issues/4427
+if sys.version_info >= (3, 8):
     from typing import Protocol, runtime_checkable
-except ImportError:
+else:
     from typing_extensions import Protocol, runtime_checkable
 
 from jsonschema._format import FormatChecker

--- a/jsonschema/tests/test_cli.py
+++ b/jsonschema/tests/test_cli.py
@@ -13,7 +13,7 @@ import tempfile
 try:  # pragma: no cover
     from importlib import metadata
 except ImportError:  # pragma: no cover
-    import importlib_metadata as metadata
+    import importlib_metadata as metadata  # type: ignore
 
 from pyrsistent import m
 

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -1663,7 +1663,7 @@ class AntiDraft6LeakMixin(object):
 
 class TestDraft3Validator(AntiDraft6LeakMixin, ValidatorTestMixin, TestCase):
     Validator = validators.Draft3Validator
-    valid: typing.Tuple[dict, dict] = {}, {}
+    valid: typing.Tuple[dict, dict] = ({}, {})
     invalid = {"type": "integer"}, "foo"
 
     def test_any_type_is_valid_for_type_any(self):
@@ -1695,31 +1695,31 @@ class TestDraft3Validator(AntiDraft6LeakMixin, ValidatorTestMixin, TestCase):
 
 class TestDraft4Validator(AntiDraft6LeakMixin, ValidatorTestMixin, TestCase):
     Validator = validators.Draft4Validator
-    valid: typing.Tuple[dict, dict] = {}, {}
+    valid: typing.Tuple[dict, dict] = ({}, {})
     invalid = {"type": "integer"}, "foo"
 
 
 class TestDraft6Validator(ValidatorTestMixin, TestCase):
     Validator = validators.Draft6Validator
-    valid: typing.Tuple[dict, dict] = {}, {}
+    valid: typing.Tuple[dict, dict] = ({}, {})
     invalid = {"type": "integer"}, "foo"
 
 
 class TestDraft7Validator(ValidatorTestMixin, TestCase):
     Validator = validators.Draft7Validator
-    valid: typing.Tuple[dict, dict] = {}, {}
+    valid: typing.Tuple[dict, dict] = ({}, {})
     invalid = {"type": "integer"}, "foo"
 
 
 class TestDraft201909Validator(ValidatorTestMixin, TestCase):
     Validator = validators.Draft201909Validator
-    valid: typing.Tuple[dict, dict] = {}, {}
+    valid: typing.Tuple[dict, dict] = ({}, {})
     invalid = {"type": "integer"}, "foo"
 
 
 class TestDraft202012Validator(ValidatorTestMixin, TestCase):
     Validator = validators.Draft202012Validator
-    valid: typing.Tuple[dict, dict] = {}, {}
+    valid: typing.Tuple[dict, dict] = ({}, {})
     invalid = {"type": "integer"}, "foo"
 
 

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import deque, namedtuple
 from contextlib import contextmanager
 from decimal import Decimal
@@ -8,7 +10,6 @@ import json
 import os
 import sys
 import tempfile
-import typing
 import unittest
 import warnings
 
@@ -1663,7 +1664,7 @@ class AntiDraft6LeakMixin(object):
 
 class TestDraft3Validator(AntiDraft6LeakMixin, ValidatorTestMixin, TestCase):
     Validator = validators.Draft3Validator
-    valid: typing.Tuple[dict, dict] = ({}, {})
+    valid: tuple[dict, dict] = ({}, {})
     invalid = {"type": "integer"}, "foo"
 
     def test_any_type_is_valid_for_type_any(self):
@@ -1695,31 +1696,31 @@ class TestDraft3Validator(AntiDraft6LeakMixin, ValidatorTestMixin, TestCase):
 
 class TestDraft4Validator(AntiDraft6LeakMixin, ValidatorTestMixin, TestCase):
     Validator = validators.Draft4Validator
-    valid: typing.Tuple[dict, dict] = ({}, {})
+    valid: tuple[dict, dict] = ({}, {})
     invalid = {"type": "integer"}, "foo"
 
 
 class TestDraft6Validator(ValidatorTestMixin, TestCase):
     Validator = validators.Draft6Validator
-    valid: typing.Tuple[dict, dict] = ({}, {})
+    valid: tuple[dict, dict] = ({}, {})
     invalid = {"type": "integer"}, "foo"
 
 
 class TestDraft7Validator(ValidatorTestMixin, TestCase):
     Validator = validators.Draft7Validator
-    valid: typing.Tuple[dict, dict] = ({}, {})
+    valid: tuple[dict, dict] = ({}, {})
     invalid = {"type": "integer"}, "foo"
 
 
 class TestDraft201909Validator(ValidatorTestMixin, TestCase):
     Validator = validators.Draft201909Validator
-    valid: typing.Tuple[dict, dict] = ({}, {})
+    valid: tuple[dict, dict] = ({}, {})
     invalid = {"type": "integer"}, "foo"
 
 
 class TestDraft202012Validator(ValidatorTestMixin, TestCase):
     Validator = validators.Draft202012Validator
-    valid: typing.Tuple[dict, dict] = ({}, {})
+    valid: tuple[dict, dict] = ({}, {})
     invalid = {"type": "integer"}, "foo"
 
 

--- a/jsonschema/tests/test_validators.py
+++ b/jsonschema/tests/test_validators.py
@@ -8,6 +8,7 @@ import json
 import os
 import sys
 import tempfile
+import typing
 import unittest
 import warnings
 
@@ -1662,7 +1663,7 @@ class AntiDraft6LeakMixin(object):
 
 class TestDraft3Validator(AntiDraft6LeakMixin, ValidatorTestMixin, TestCase):
     Validator = validators.Draft3Validator
-    valid = {}, {}
+    valid: typing.Tuple[dict, dict] = {}, {}
     invalid = {"type": "integer"}, "foo"
 
     def test_any_type_is_valid_for_type_any(self):
@@ -1694,31 +1695,31 @@ class TestDraft3Validator(AntiDraft6LeakMixin, ValidatorTestMixin, TestCase):
 
 class TestDraft4Validator(AntiDraft6LeakMixin, ValidatorTestMixin, TestCase):
     Validator = validators.Draft4Validator
-    valid = {}, {}
+    valid: typing.Tuple[dict, dict] = {}, {}
     invalid = {"type": "integer"}, "foo"
 
 
 class TestDraft6Validator(ValidatorTestMixin, TestCase):
     Validator = validators.Draft6Validator
-    valid = {}, {}
+    valid: typing.Tuple[dict, dict] = {}, {}
     invalid = {"type": "integer"}, "foo"
 
 
 class TestDraft7Validator(ValidatorTestMixin, TestCase):
     Validator = validators.Draft7Validator
-    valid = {}, {}
+    valid: typing.Tuple[dict, dict] = {}, {}
     invalid = {"type": "integer"}, "foo"
 
 
 class TestDraft201909Validator(ValidatorTestMixin, TestCase):
     Validator = validators.Draft201909Validator
-    valid = {}, {}
+    valid: typing.Tuple[dict, dict] = {}, {}
     invalid = {"type": "integer"}, "foo"
 
 
 class TestDraft202012Validator(ValidatorTestMixin, TestCase):
     Validator = validators.Draft202012Validator
-    valid = {}, {}
+    valid: typing.Tuple[dict, dict] = {}, {}
     invalid = {"type": "integer"}, "foo"
 
 

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -1,6 +1,8 @@
 """
 Creation and extension of validators, with implementations for existing drafts.
 """
+from __future__ import annotations
+
 from collections import deque
 from collections.abc import Sequence
 from functools import lru_cache
@@ -23,9 +25,9 @@ from jsonschema import (
     exceptions,
 )
 
-_VALIDATORS: typing.Dict[str, typing.Any] = {}
+_VALIDATORS: dict[str, typing.Any] = {}
 _META_SCHEMAS = _utils.URIDict()
-_VOCABULARIES: typing.List[typing.Tuple[str, typing.Any]] = []
+_VOCABULARIES: list[tuple[str, typing.Any]] = []
 
 
 def __getattr__(name):

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -10,6 +10,7 @@ from warnings import warn
 import contextlib
 import json
 import reprlib
+import typing
 import warnings
 
 import attr
@@ -22,9 +23,9 @@ from jsonschema import (
     exceptions,
 )
 
-_VALIDATORS = {}
+_VALIDATORS: typing.Dict[str, typing.Any] = {}
 _META_SCHEMAS = _utils.URIDict()
-_VOCABULARIES = []
+_VOCABULARIES: typing.List[typing.Tuple[str, typing.Any]] = []
 
 
 def __getattr__(name):

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,9 @@ ignore =
     B306,  # See https://github.com/PyCQA/flake8-bugbear/issues/131
     W503,  # (flake8 default) old PEP8 boolean operator line breaks
 
+[mypy]
+ignore_missing_imports = true
+
 [pydocstyle]
 match = (?!(test_|_|compat|cli)).*\.py  # see PyCQA/pydocstyle#323
 add-select =

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     safety
     secrets
     style
+    typing
     docs-{html,doctest,linkcheck,spelling,style}
 skipsdist = True
 
@@ -88,6 +89,15 @@ deps =
     flake8-tidy-imports
 commands =
     {envpython} -m flake8 {posargs} {toxinidir}/jsonschema {toxinidir}/docs
+
+[testenv:typing]
+skip_install = true
+deps =
+    mypy
+    pyrsistent
+    types-attrs
+    types-requests
+commands = {envpython} -m mypy --config {toxinidir}/setup.cfg {posargs} {toxinidir}/jsonschema
 
 [testenv:docs-dirhtml]
 commands = {envpython} -m sphinx -b dirhtml {toxinidir}/docs/ {envtmpdir}/build {posargs:-a -n -q -T -W}


### PR DESCRIPTION
This is the smallest possible change to get mypy passing on the jsonschema codebase. The goal of this configuration is to enforce type annotations anywhere that they appear.
That is, if a method is added to the codebase,

    def foo(x: int) -> str:
        return str(x)

then usages of `foo` will by type checked. If no annotations are added, `mypy` will not type check functions.

For the most part, this keeps the impact low. The one exceptional case is the use of `pyrsistent.pmap` as an argument to `attr.ib(converter=...)`. Unfortunately, it causes `mypy` to incorrectly deduce the type of the init parameter created by attrs. We need to "explain the type of init" to mypy by creating a callable with a concrete type to act as the converter. The callable in question simply wraps `pmap` with a cast and presents the desired type
information to mypy.

---

A few asides:

I see some whitespace edits crept in when I `black`ed files. I'll back those out when I can work on this more next week.

I personally like `import typing as t` and then using `t.Optional`, `t.Dict`, etc. throughout a codebase. But there are various opinions on this, so I've gone with `import typing` and `typing.Optional`, etc. as what I believe is the least controversial choice.

`tox -e typing` seemed consistent with `tox -e style`: name the env by the thing being checked, not the tool used to check it. `tox -e mypy` would also work.

Type checking enforcement is somewhat necessary if we are to consider publishing type information from `jsonschema`. I don't know if this is really desirable, but the PR shows what it would take to get type checking to pass.