### PR TITLE
perf: Undesired fallback to brute force container uniqueness check on certain input types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,6 @@
+
+* Fix undesired fallback to brute force container uniqueness check on certain input types
+
 v4.2.1
 ------
 

--- a/jsonschema/_utils.py
+++ b/jsonschema/_utils.py
@@ -188,7 +188,7 @@ def uniq(container):
         sliced = itertools.islice(sort, 1, None)
 
         for i, j in zip(sort, sliced):
-            if _sequence_equal(i, j):
+            if equal(i, j):
                 return False
 
     except (NotImplementedError, TypeError):


### PR DESCRIPTION
Hi!

I noticed, that the `uniq` implementation uses `_sequence_equal` if the input is sortable. Then, if e.g. `[1, 2, 3, 4, 5]` is passed to `uniq`, then it falls back to brute force because on the first loop iteration `_sequence_equal` fails with `TypeError: object of type 'int' has no len()`, but it should not as a list of ints is sortable & straightforward to compare.

Code sample:

```python
CONTAINER = list(range(100))
assert uniq(CONTAINER)
assert not uniq([1, 1])
start = time.perf_counter()
for _ in range(1000):
    uniq(CONTAINER)
print(time.perf_counter() - start)
```

Before: 5.4033913369985385s
After: 0.12076822199924209s

I didn't check whether this was the direct cause of #853, but hopefully, it can improve the status quo :)

**Update**: The change doesn't affect #853 much (measured by the  code sample from the first comment there):
Before: 27.133657693862915 sec
After: 26.14994215965271 sec