### PR TITLE
perf: Cache reference lookups for subschemas

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ v4.3.0
   certain input types (#893)
 * Cache reference lookups for subschemas (#893)
 * Use cached lookups for resolving fragments if the referent document is known (#893)
+* Replace the ``Validator.evolve`` method with an equivalent class attribute
 * Implement a PEP544 Protocol for validator classes (#890)
 
 v4.2.1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ v4.3.0
 * Fix undesired fallback to brute force container uniqueness check on
   certain input types (#893)
 * Cache reference lookups for subschemas (#893)
+* Use cached lookups for resolving fragments if the referent document is known (#893)
 * Implement a PEP544 Protocol for validator classes (#890)
 
 v4.2.1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ v4.3.0
 
 * Fix undesired fallback to brute force container uniqueness check on
   certain input types (#893)
+* Cache reference lookups for subschemas (#893)
 * Implement a PEP544 Protocol for validator classes (#890)
 
 v4.2.1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,9 +3,7 @@ v4.3.0
 
 * Fix undesired fallback to brute force container uniqueness check on
   certain input types (#893)
-* Cache reference lookups for subschemas (#893)
-* Use cached lookups for resolving fragments if the referent document is known (#893)
-* Replace the ``Validator.evolve`` method with an equivalent class attribute
+* Resolving refs has had performance improvements (#893)
 * Implement a PEP544 Protocol for validator classes (#890)
 
 v4.2.1

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -169,6 +169,7 @@ def create(
         schema = attr.ib(repr=reprlib.repr)
         resolver = attr.ib(default=None, repr=False)
         format_checker = attr.ib(default=None)
+        evolve = attr.evolve
 
         def __attrs_post_init__(self):
             if self.resolver is None:
@@ -181,9 +182,6 @@ def create(
         def check_schema(cls, schema):
             for error in cls(cls.META_SCHEMA).iter_errors(schema):
                 raise exceptions.SchemaError.create_from(error)
-
-        def evolve(self, **kwargs):
-            return attr.evolve(self, **kwargs)
 
         def iter_errors(self, instance, _schema=None):
             if _schema is not None:


### PR DESCRIPTION
The latest commit cuts the time to 8.08942461013794 sec which is quite close to `3.2.0` version performance (5.38702654838562 sec on my machine)