### PR TITLE
Move warnings to user context

### DIFF
--- a/jsonschema/__init__.py
+++ b/jsonschema/__init__.py
@@ -46,6 +46,7 @@ def __getattr__(name):
             "removed in a future release. Use importlib.metadata directly "
             "to query for jsonschema's version.",
             DeprecationWarning,
+            stacklevel=2,
         )
 
         try:

--- a/jsonschema/tests/test_deprecations.py
+++ b/jsonschema/tests/test_deprecations.py
@@ -12,6 +12,7 @@ class TestDeprecations(TestCase):
         with self.assertWarns(DeprecationWarning) as w:
             from jsonschema import __version__  # noqa
 
+        self.assertEqual(w.filename, __file__)
         self.assertTrue(
             str(w.warning).startswith(
                 "Accessing jsonschema.__version__ is deprecated",
@@ -27,6 +28,7 @@ class TestDeprecations(TestCase):
         with self.assertWarns(DeprecationWarning) as w:
             from jsonschema.validators import ErrorTree  # noqa
 
+        self.assertEqual(w.filename, __file__)
         self.assertTrue(
             str(w.warning).startswith(
                 "Importing ErrorTree from jsonschema.validators is deprecated",
@@ -43,6 +45,7 @@ class TestDeprecations(TestCase):
             value = validators.validators
         self.assertEqual(value, validators._VALIDATORS)
 
+        self.assertEqual(w.filename, __file__)
         self.assertTrue(
             str(w.warning).startswith(
                 "Accessing jsonschema.validators.validators is deprecated",
@@ -59,6 +62,7 @@ class TestDeprecations(TestCase):
             value = validators.meta_schemas
         self.assertEqual(value, validators._META_SCHEMAS)
 
+        self.assertEqual(w.filename, __file__)
         self.assertTrue(
             str(w.warning).startswith(
                 "Accessing jsonschema.validators.meta_schemas is deprecated",
@@ -75,6 +79,7 @@ class TestDeprecations(TestCase):
             with resolver.in_scope("foo"):
                 pass
 
+        self.assertEqual(w.filename, __file__)
         self.assertTrue(
             str(w.warning).startswith(
                 "jsonschema.RefResolver.in_scope is deprecated ",
@@ -92,6 +97,7 @@ class TestDeprecations(TestCase):
             result = validator.is_valid("foo", {"type": "number"})
 
         self.assertFalse(result)
+        self.assertEqual(w.filename, __file__)
         self.assertTrue(
             str(w.warning).startswith(
                 "Passing a schema to Validator.is_valid is deprecated ",
@@ -109,6 +115,7 @@ class TestDeprecations(TestCase):
             error, = validator.iter_errors("foo", {"type": "number"})
 
         self.assertEqual(error.validator, "type")
+        self.assertEqual(w.filename, __file__)
         self.assertTrue(
             str(w.warning).startswith(
                 "Passing a schema to Validator.iter_errors is deprecated ",

--- a/jsonschema/validators.py
+++ b/jsonschema/validators.py
@@ -33,6 +33,7 @@ def __getattr__(name):
             "Importing ErrorTree from jsonschema.validators is deprecated. "
             "Instead import it from jsonschema.exceptions.",
             DeprecationWarning,
+            stacklevel=2,
         )
         from jsonschema.exceptions import ErrorTree
         return ErrorTree
@@ -41,6 +42,7 @@ def __getattr__(name):
             "Accessing jsonschema.validators.validators is deprecated. "
             "Use jsonschema.validators.validator_for with a given schema.",
             DeprecationWarning,
+            stacklevel=2,
         )
         return _VALIDATORS
     elif name == "meta_schemas":
@@ -48,6 +50,7 @@ def __getattr__(name):
             "Accessing jsonschema.validators.meta_schemas is deprecated. "
             "Use jsonschema.validators.validator_for with a given schema.",
             DeprecationWarning,
+            stacklevel=2,
         )
         return _META_SCHEMAS
     raise AttributeError(f"module {__name__} has no attribute {name}")
@@ -193,6 +196,7 @@ def create(
                         "iter_errors(...) instead."
                     ),
                     DeprecationWarning,
+                    stacklevel=2,
                 )
             else:
                 _schema = self.schema
@@ -262,6 +266,7 @@ def create(
                         "instead."
                     ),
                     DeprecationWarning,
+                    stacklevel=2,
                 )
                 self = self.evolve(schema=_schema)
 
@@ -727,6 +732,7 @@ class RefResolver(object):
             "jsonschema.RefResolver.in_scope is deprecated and will be "
             "removed in a future release.",
             DeprecationWarning,
+            stacklevel=3,
         )
         self.push_scope(scope)
         try:


### PR DESCRIPTION
Currently the warning location points inside the `jsonschema` code and it takes an additional effort to find where the actual code that triggers it is located.