### PR TITLE
Remove stray double-quote

### DIFF
--- a/jsonschema/cli.py
+++ b/jsonschema/cli.py
@@ -157,7 +157,7 @@ parser.add_argument(
         one formatted object named 'error' for each ValidationError.
         Only provide this option when using --output=plain, which is the
         default. If this argument is unprovided and --output=plain is
-        used, a simple default representation will be used."
+        used, a simple default representation will be used.
     """,
 )
 parser.add_argument(


### PR DESCRIPTION
The help-string for --error-format is triple-quoted, so remove unnecessary quote character